### PR TITLE
Integrate Image Builder to push Released images to MCR Repo

### DIFF
--- a/BuildAndTagImages/build.sh
+++ b/BuildAndTagImages/build.sh
@@ -28,35 +28,33 @@ function buildDockerImage()
             for TAG in "${STACK_TAGS_ARR[@]}"
             do
                 # Build Image Tags are converted to lower case because docker doesn't accept upper case tags
-                local AppSvcTagUpperCaseDocker="${APP_SVC_BRANCH_PREFIX}/${STACK}:${TAG}"
-                local AppSvcTagDocker="${AppSvcTagUpperCaseDocker,,}"
                 local TestRepoTagUpperCase="${TEST_IMAGE_REPO_NAME}/${STACK}:${TAG}_${PIPELINE_BUILD_NUMBER}"
                 local TestRepoTag="${TestRepoTagUpperCase,,}"
                 local appSvcDockerfilePath="${SYSTEM_ARTIFACTS_DIR}/${STACK}/GitRepo/${STACK_VERSION}/Dockerfile" 
-                echo "Listing artifacts dir"
+                
+		echo "Listing artifacts dir"
                 ls "${SYSTEM_ARTIFACTS_DIR}"
                 echo "Listing stacks dir"
                 ls "${SYSTEM_ARTIFACTS_DIR}/${STACK}/GitRepo/${STACK_VERSION}"
                 cd "${SYSTEM_ARTIFACTS_DIR}/${STACK}/GitRepo/${STACK_VERSION}"
+
                 echo
                 echo "Building test image with tag '$TestRepoTag' and file $appSvcDockerfilePath..."
                 echo docker build -t "$TestRepoTag" -f "$appSvcDockerfilePath" .
                 docker build -t "$TestRepoTag" -f "$appSvcDockerfilePath" .
+
                 if [ "$BUILD_REASON" != "PullRequest" ]; then
                     docker push $TestRepoTag
                 fi
+
                 echo $TestRepoTag > $SYSTEM_ARTIFACTS_DIR/builtImageList
-                echo "Pushing test image to $AppSvcTagDocker"
-                docker tag $TestRepoTag $AppSvcTagDocker
-                if [ "$BUILD_REASON" != "PullRequest" ]; then
-                    docker push $AppSvcTagDocker
-                fi
             done
         done < "$CONFIG_DIR/${STACK}VersionTemplateMap.txt"
     else
+    	# KuduLite Image, add single image support
         local TestRepoTagUpperCase="${TEST_IMAGE_REPO_NAME}/${STACK}:${PIPELINE_BUILD_NUMBER}"
         local TestRepoTag="${TestRepoTagUpperCase,,}"
-        local appSvcDockerfilePath="${SYSTEM_ARTIFACTS_DIR}/${STACK}/GitRepo/kudu/Dockerfile" 
+        local appSvcDockerfilePath="${SYSTEM_ARTIFACTS_DIR}/${STACK}/GitRepo/kudu/Dockerfile"
         echo "Listing artifacts dir"
         ls "${SYSTEM_ARTIFACTS_DIR}"
         echo "Listing stacks dir"
@@ -66,9 +64,12 @@ function buildDockerImage()
         echo "Building test image with tag '$TestRepoTag' and file $appSvcDockerfilePath..."
         echo docker build -t "$TestRepoTag" -f "$appSvcDockerfilePath" .
         docker build -t "$TestRepoTag" -f "$appSvcDockerfilePath" .
+	
+	# only push the images if merging to the master
         if [ "$BUILD_REASON" != "PullRequest" ]; then
             docker push $TestRepoTag
         fi
+
         echo $TestRepoTag > $SYSTEM_ARTIFACTS_DIR/builtImageList
     fi
 }

--- a/BuildAndTagImages/buildImageJob.yml
+++ b/BuildAndTagImages/buildImageJob.yml
@@ -20,12 +20,6 @@ steps:
     azureSubscriptionEndpoint: ${{ parameters.ascName }}
     azureContainerRegistry: ${{ parameters.acrName }}
 
-- task: Docker@2
-  displayName: DockerHub login
-  inputs:
-    command: login
-    containerRegistry: App Svc Test Docker Hub
-    
 - task: DownloadBuildArtifacts@0
   displayName: 'Download Build Artifacts'
   inputs:

--- a/Config/stacks.txt
+++ b/Config/stacks.txt
@@ -1,2 +1,0 @@
-dotnetcore
-node

--- a/GenerateDockerFiles/KuduLite/generateDockerfiles.sh
+++ b/GenerateDockerFiles/KuduLite/generateDockerfiles.sh
@@ -23,8 +23,8 @@ declare -r APP_SVC_REPO_BRANCH="dev"
 function generateDockerFiles()
 {
    
-	# Example line:
-	# 1.0 -> uses Oryx Base Image mcr.microsoft.com/oryx/build:$BASE_IMAGE_VERSION_STREAM_FEED
+    # Example line:
+    # 1.0 -> uses Oryx Base Image mcr.microsoft.com/oryx/build:$BASE_IMAGE_VERSION_STREAM_FEED
 
     # Base Image
     BASE_IMAGE_NAME="${BASE_IMAGE_REPO_NAME}:$BASE_IMAGE_VERSION_STREAM_FEED"

--- a/GenerateDockerFiles/node/generateDockerfiles.sh
+++ b/GenerateDockerFiles/node/generateDockerfiles.sh
@@ -2,7 +2,7 @@
 # --------------------------------------------------------------------------------------------
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT license.
-# This script generates Dockerfiles for ASP .NETCore Runtime Images for Azure App Service on Linux.
+# This script generates Dockerfiles for NodeJS Runtime Images for Azure App Service on Linux.
 # --------------------------------------------------------------------------------------------
 
 set -e
@@ -29,22 +29,22 @@ function generateDockerFiles()
 	# 1.0 -> uses Oryx Base Image mcr.microsoft.com/oryx/dotnetcore:1.0-$BASE_IMAGE_VERSION_STREAM_FEED
 	while IFS=, read -r STACK_VERSION BASE_IMAGE STACK_VERSION_TEMPLATE_DIR STACK_TAGS || [[ -n $STACK_VERSION ]] || [[ -n $BASE_IMAGE ]] || [[ -n $STACK_VERSION_TEMPLATE_DIR ]] || [[ -n $STACK_TAGS ]]
 	do
-        # Base Image
-        BASE_IMAGE_NAME="${BASE_IMAGE_REPO_NAME}:${BASE_IMAGE}-$BASE_IMAGE_VERSION_STREAM_FEED"
-        CURR_VERSION_DIRECTORY="${APP_SVC_REPO_DIR}/${STACK_VERSION}"
-        TARGET_DOCKERFILE="${CURR_VERSION_DIRECTORY}/Dockerfile"
+            # Base Image
+            BASE_IMAGE_NAME="${BASE_IMAGE_REPO_NAME}:${BASE_IMAGE}-$BASE_IMAGE_VERSION_STREAM_FEED"
+            CURR_VERSION_DIRECTORY="${APP_SVC_REPO_DIR}/${STACK_VERSION}"
+            TARGET_DOCKERFILE="${CURR_VERSION_DIRECTORY}/Dockerfile"
 
-        echo "Generating App Service Dockerfile and dependencies for image '$BASE_IMAGE_NAME' in directory '$CURR_VERSION_DIRECTORY'..."
+            echo "Generating App Service Dockerfile and dependencies for image '$BASE_IMAGE_NAME' in directory '$CURR_VERSION_DIRECTORY'..."
 
-        # Remove Existing Version directory, eg: GitRepo/1.0 to replace with realized files
-        rm -rf "$CURR_VERSION_DIRECTORY"
-        mkdir -p "$CURR_VERSION_DIRECTORY"
-        cp -R ${DIR}/${STACK_VERSION_TEMPLATE_DIR}/* "$CURR_VERSION_DIRECTORY"
+            # Remove Existing Version directory, eg: GitRepo/1.0 to replace with realized files
+            rm -rf "$CURR_VERSION_DIRECTORY"
+            mkdir -p "$CURR_VERSION_DIRECTORY"
+            cp -R ${DIR}/${STACK_VERSION_TEMPLATE_DIR}/* "$CURR_VERSION_DIRECTORY"
 
-        # Replace placeholders, changing sed delimeter since '/' is used in path
-        sed -i "s|BASE_IMAGE_NAME_PLACEHOLDER|$BASE_IMAGE_NAME|g" "$TARGET_DOCKERFILE"
+            # Replace placeholders, changing sed delimeter since '/' is used in path
+            sed -i "s|BASE_IMAGE_NAME_PLACEHOLDER|$BASE_IMAGE_NAME|g" "$TARGET_DOCKERFILE"
         
-        echo "Done."
+            echo "Done."
 
 	done < "$stackVersionsMapFilePath"
 }

--- a/GenerateDockerFiles/php-xdebug/generateDockerfiles.sh
+++ b/GenerateDockerFiles/php-xdebug/generateDockerfiles.sh
@@ -2,7 +2,7 @@
 # --------------------------------------------------------------------------------------------
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT license.
-# This script generates Dockerfiles for ASP .NETCore Runtime Images for Azure App Service on Linux.
+# This script generates Dockerfiles for php debug Images for Azure App Service on Linux.
 # --------------------------------------------------------------------------------------------
 
 set -e
@@ -29,21 +29,21 @@ function generateDockerFiles()
 	# 1.0 -> uses Oryx Base Image mcr.microsoft.com/oryx/php:1.0-$BASE_IMAGE_VERSION
 	while IFS=, read -r STACK_VERSION BASE_IMAGE STACK_VERSION_TEMPLATE_DIR STACK_TAGS || [[ -n $STACK_VERSION ]] || [[ -n $BASE_IMAGE ]] || [[ -n $STACK_VERSION_TEMPLATE_DIR ]] || [[ -n $STACK_TAGS ]]
 	do
-        # Base Image
-        BASE_IMAGE_NAME="${BASE_IMAGE_REPO_NAME}:${BASE_IMAGE}"
-        CURR_VERSION_DIRECTORY="${APP_SVC_REPO_DIR}/${STACK_VERSION}"
-        TARGET_DOCKERFILE="${CURR_VERSION_DIRECTORY}/Dockerfile"
+            # Base Image
+            BASE_IMAGE_NAME="${BASE_IMAGE_REPO_NAME}:${BASE_IMAGE}"
+            CURR_VERSION_DIRECTORY="${APP_SVC_REPO_DIR}/${STACK_VERSION}"
+            TARGET_DOCKERFILE="${CURR_VERSION_DIRECTORY}/Dockerfile"
 
-        echo "Generating App Service Dockerfile and dependencies for image '$BASE_IMAGE_NAME' in directory '$CURR_VERSION_DIRECTORY'..."
+            echo "Generating App Service Dockerfile and dependencies for image '$BASE_IMAGE_NAME' in directory '$CURR_VERSION_DIRECTORY'..."
 
-        # Remove Existing Version directory, eg: GitRepo/1.0 to replace with realized files
-        rm -rf "$CURR_VERSION_DIRECTORY"
-        mkdir -p "$CURR_VERSION_DIRECTORY"
-        cp -R ${DIR}/${STACK_VERSION_TEMPLATE_DIR}/* "$CURR_VERSION_DIRECTORY"
+            # Remove Existing Version directory, eg: GitRepo/1.0 to replace with realized files
+            rm -rf "$CURR_VERSION_DIRECTORY"
+            mkdir -p "$CURR_VERSION_DIRECTORY"
+            cp -R ${DIR}/${STACK_VERSION_TEMPLATE_DIR}/* "$CURR_VERSION_DIRECTORY"
 
-        # Replace placeholders, changing sed delimeter since '/' is used in path
-        sed -i "s|BASE_IMAGE_NAME_PLACEHOLDER|$BASE_IMAGE_NAME|g" "$TARGET_DOCKERFILE"
-        echo "Done."
+            # Replace placeholders, changing sed delimeter since '/' is used in path
+            sed -i "s|BASE_IMAGE_NAME_PLACEHOLDER|$BASE_IMAGE_NAME|g" "$TARGET_DOCKERFILE"
+            echo "Done."
 
 	done < "$stackVersionsMapFilePath"
 }

--- a/GenerateDockerFiles/php/generateDockerfiles.sh
+++ b/GenerateDockerFiles/php/generateDockerfiles.sh
@@ -2,7 +2,8 @@
 # --------------------------------------------------------------------------------------------
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT license.
-# This script generates Dockerfiles for ASP .NETCore Runtime Images for Azure App Service on Linux.
+# This script generates Dockerfiles for PHP Runtime and Debug Images for Azure App Service on Linux.
+# The debug images are tagged using -xdebug suffix.
 # --------------------------------------------------------------------------------------------
 
 set -e
@@ -28,22 +29,23 @@ function generateDockerFiles()
 	# 1.0 -> uses Oryx Base Image mcr.microsoft.com/oryx/php:1.0-$BASE_IMAGE_VERSION
 	while IFS=, read -r STACK_VERSION BASE_IMAGE STACK_VERSION_TEMPLATE_DIR STACK_TAGS || [[ -n $STACK_VERSION ]] || [[ -n $BASE_IMAGE ]] || [[ -n $STACK_VERSION_TEMPLATE_DIR ]] || [[ -n $STACK_TAGS ]]
 	do
-        # Base Image
-        BASE_IMAGE_NAME="${BASE_IMAGE_REPO_NAME}:${BASE_IMAGE}-${BASE_IMAGE_VERSION}"
-        CURR_VERSION_DIRECTORY="${APP_SVC_REPO_DIR}/${STACK_VERSION}"
-        TARGET_DOCKERFILE="${CURR_VERSION_DIRECTORY}/Dockerfile"
 
-        echo "Generating App Service Dockerfile and dependencies for image '$BASE_IMAGE_NAME' in directory '$CURR_VERSION_DIRECTORY'..."
+            # Base Image
+            BASE_IMAGE_NAME="${BASE_IMAGE_REPO_NAME}:${BASE_IMAGE}-${BASE_IMAGE_VERSION}"
+            CURR_VERSION_DIRECTORY="${APP_SVC_REPO_DIR}/${STACK_VERSION}"
+            TARGET_DOCKERFILE="${CURR_VERSION_DIRECTORY}/Dockerfile"
 
-        # Remove Existing Version directory, eg: GitRepo/1.0 to replace with realized files
-        rm -rf "$CURR_VERSION_DIRECTORY"
-        mkdir -p "$CURR_VERSION_DIRECTORY"
-        cp -R ${DIR}/${STACK_VERSION_TEMPLATE_DIR}/* "$CURR_VERSION_DIRECTORY"
+            echo "Generating App Service Dockerfile and dependencies for image '$BASE_IMAGE_NAME' in directory '$CURR_VERSION_DIRECTORY'..."
 
-        # Replace placeholders, changing sed delimeter since '/' is used in path
-        sed -i "s|BASE_IMAGE_NAME_PLACEHOLDER|$BASE_IMAGE_NAME|g" "$TARGET_DOCKERFILE"
-        sed -i "s|VERSION_PLACEHOLDER|$BASE_IMAGE_VERSION|g" "$TARGET_DOCKERFILE"
-        echo "Done."
+            # Remove Existing Version directory, eg: GitRepo/1.0 to replace with realized files
+            rm -rf "$CURR_VERSION_DIRECTORY"
+            mkdir -p "$CURR_VERSION_DIRECTORY"
+            cp -R ${DIR}/${STACK_VERSION_TEMPLATE_DIR}/* "$CURR_VERSION_DIRECTORY"
+
+            # Replace placeholders, changing sed delimeter since '/' is used in path
+            sed -i "s|BASE_IMAGE_NAME_PLACEHOLDER|$BASE_IMAGE_NAME|g" "$TARGET_DOCKERFILE"
+            sed -i "s|VERSION_PLACEHOLDER|$BASE_IMAGE_VERSION|g" "$TARGET_DOCKERFILE"
+            echo "Done."
 
 	done < "$stackVersionsMapFilePath"
 }

--- a/GenerateDockerFiles/python/generateDockerfiles.sh
+++ b/GenerateDockerFiles/python/generateDockerfiles.sh
@@ -2,7 +2,7 @@
 # --------------------------------------------------------------------------------------------
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT license.
-# This script generates Dockerfiles for ASP .NETCore Runtime Images for Azure App Service on Linux.
+# This script generates Dockerfiles for Python Images for Azure App Service on Linux.
 # --------------------------------------------------------------------------------------------
 
 set -e
@@ -29,24 +29,23 @@ function generateDockerFiles()
 	# 1.0 -> uses Oryx Base Image mcr.microsoft.com/oryx/dotnetcore:1.0-$BASE_IMAGE_VERSION_STREAM_FEED
 	while IFS=, read -r STACK_VERSION BASE_IMAGE STACK_VERSION_TEMPLATE_DIR STACK_TAGS || [[ -n $STACK_VERSION ]] || [[ -n $BASE_IMAGE ]] || [[ -n $STACK_VERSION_TEMPLATE_DIR ]] || [[ -n $STACK_TAGS ]]
 	do
-        # Base Image
-        BASE_IMAGE_NAME="${BASE_IMAGE_REPO_NAME}:${BASE_IMAGE}-$BASE_IMAGE_VERSION_STREAM_FEED"
-        CURR_VERSION_DIRECTORY="${APP_SVC_REPO_DIR}/${STACK_VERSION}"
-        TARGET_DOCKERFILE="${CURR_VERSION_DIRECTORY}/Dockerfile"
+            # Base Image
+            BASE_IMAGE_NAME="${BASE_IMAGE_REPO_NAME}:${BASE_IMAGE}-$BASE_IMAGE_VERSION_STREAM_FEED"
+            CURR_VERSION_DIRECTORY="${APP_SVC_REPO_DIR}/${STACK_VERSION}"
+            TARGET_DOCKERFILE="${CURR_VERSION_DIRECTORY}/Dockerfile"
 
-        echo "Generating App Service Dockerfile and dependencies for image '$BASE_IMAGE_NAME' in directory '$CURR_VERSION_DIRECTORY'..."
+            echo "Generating App Service Dockerfile and dependencies for image '$BASE_IMAGE_NAME' in directory '$CURR_VERSION_DIRECTORY'..."
+            # Remove Existing Version directory, eg: GitRepo/1.0 to replace with realized files
+            rm -rf "$CURR_VERSION_DIRECTORY"
+            mkdir -p "$CURR_VERSION_DIRECTORY"
+            cp -R ${DIR}/${STACK_VERSION_TEMPLATE_DIR}/* "$CURR_VERSION_DIRECTORY"
 
-        # Remove Existing Version directory, eg: GitRepo/1.0 to replace with realized files
-        rm -rf "$CURR_VERSION_DIRECTORY"
-        mkdir -p "$CURR_VERSION_DIRECTORY"
-        cp -R ${DIR}/${STACK_VERSION_TEMPLATE_DIR}/* "$CURR_VERSION_DIRECTORY"
-
-        # Replace placeholders, changing sed delimeter since '/' is used in path
-        sed -i "s|BASE_IMAGE_NAME_PLACEHOLDER|$BASE_IMAGE_NAME|g" "$TARGET_DOCKERFILE"
+            # Replace placeholders, changing sed delimeter since '/' is used in path
+            sed -i "s|BASE_IMAGE_NAME_PLACEHOLDER|$BASE_IMAGE_NAME|g" "$TARGET_DOCKERFILE"
         
-        echo "Done."
+            echo "Done."
 
-	done < "$stackVersionsMapFilePath"
+        done < "$stackVersionsMapFilePath"
 }
 
 function pullAppSvcRepo()

--- a/Release/release.sh
+++ b/Release/release.sh
@@ -31,7 +31,7 @@ function tagACRImagesToDockerHub()
                 # Tag images from APP_SVC_DEV_ACR to APP_SVC_MCR_REPO
                 local imageName="${STACK}:${TAG}"
                 local acrImage="${APP_SVC_DEV_ACR}/${imageName}"
-                local mcrImage="${APP_SVC_MCR_REPO}/public/${imageName}"
+                local mcrImage="${APP_SVC_MCR_REPO}/public/appsvc/${imageName}"
                 echo "Pulling from test acr. Image: $acrImage"
                 docker pull ${acrImage}
                 echo "Tagging image test image to prod ACR"

--- a/Release/release.sh
+++ b/Release/release.sh
@@ -2,21 +2,23 @@
 # --------------------------------------------------------------------------------------------
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT license.
-# This script publishes images to dockerhub for Azure App Services on Linux
+# This script publishes the runtime and the build images to Microsoft Container Registry 
+# for Azure App Services on Linux
 # --------------------------------------------------------------------------------------------
 
 set -e
 
-# Set BUILD to the images' build number you wish to push to APP_SVC_DOCKER_REPO
+# Set BUILD to the images' build number you wish to push to APP_SVC_MCR_REPO
+# TODO: Move to Params
 declare -r BUILD="20191114.1"
 
 declare -r DEFAULT_WORKING_DIRECTORY="$1" # $(System.DefaultWorkingDirectory)
-declare -r APP_SVC_DOCKER_REPO="appsvc"
+declare -r APP_SVC_MCR_REPO="wawsimages.azurecr.io"
 declare -r APP_SVC_DEV_ACR="appsvcdevacr.azurecr.io"
 
 function tagACRImagesToDockerHub()
 {
-    echo "Tagging acr images to dockerhub"
+    echo "Tagging test acr images and pushing them to MCR"
     echo "Build number is $BUILD"
 
     while IFS=, read -r STACK ||  [[ -n $STACK ]]
@@ -26,20 +28,19 @@ function tagACRImagesToDockerHub()
         do
             if [[ $TAG == *$BUILD ]]
             then
-                # Tag images from APP_SVC_DEV_ACR to APP_SVC_DOCKER_REPO
+                # Tag images from APP_SVC_DEV_ACR to APP_SVC_MCR_REPO
                 local imageName="${STACK}:${TAG}"
                 local acrImage="${APP_SVC_DEV_ACR}/${imageName}"
-                local dockerHubImage="${APP_SVC_DOCKER_REPO}/${imageName}"
-                echo "Pulling from acr. Image: $acrImage"
+                local mcrImage="${APP_SVC_MCR_REPO}/public/${imageName}"
+                echo "Pulling from test acr. Image: $acrImage"
                 docker pull ${acrImage}
-                echo "Tagging image"
-                docker tag ${acrImage} ${dockerHubImage}
-                echo "Pushing image to $dockerHubImage"
-                docker push ${dockerHubImage}
+                echo "Tagging image test image to prod ACR"
+                docker tag ${acrImage} ${mcrImage}
+                echo "Pushing image $mcrImage"
+                docker push ${mcrImage}
             fi
         done < "$DEFAULT_WORKING_DIRECTORY/tags/$STACK"
     done < "$DEFAULT_WORKING_DIRECTORY/tags_list"
 }
 
 tagACRImagesToDockerHub
-

--- a/Release/release.yml
+++ b/Release/release.yml
@@ -43,7 +43,7 @@ jobs:
             az acr repository show-tags -n appsvcdevacr --repository $repo -o tsv > $(System.DefaultWorkingDirectory)/tags/$repo
           done
   - task: ShellScript@2
-    displayName: 'Push approved images from AppSvcDevACR to appsvctest'
+    displayName: 'Push approved images from AppSvcDevACR to WAWSImages'
     inputs:
       scriptPath: ./Release/release.sh
       args: $(System.DefaultWorkingDirectory)

--- a/Release/release.yml
+++ b/Release/release.yml
@@ -14,16 +14,17 @@ jobs:
   timeoutInMinutes: 100
   steps:
   - task: Docker@1
-    displayName: ACR login
+    displayName: Dev ACR login
     inputs:
       command: login
       azureSubscriptionEndpoint: AppSvcDevACR
       azureContainerRegistry: appsvcdevacr.azurecr.io
-  - task: Docker@2
-    displayName: DockerHub login
+  - task: Docker@1
+    displayName: WAWS Container Images ACR login
     inputs:
       command: login
-      containerRegistry: App Svc Test Docker Hub
+      azureSubscriptionEndpoint:  WAWS_Container_Images
+      azureContainerRegistry: wawsimages.azurecr.io
   - task: AzureCLI@2
     displayName: Azure CLI
     inputs:
@@ -46,5 +47,4 @@ jobs:
     inputs:
       scriptPath: ./Release/release.sh
       args: $(System.DefaultWorkingDirectory)
-
 trigger: none

--- a/Release/release.yml
+++ b/Release/release.yml
@@ -8,7 +8,7 @@ variables:
 jobs:
 
 - job: Job_TagAppSvcTestImages
-  displayName: Tag ACR Dev Repo Images to Test
+  displayName: Publish Images
   pool:
     vmImage: ubuntu-16.04
   timeoutInMinutes: 100


### PR DESCRIPTION
This PR adds functionality to push the approved images to MCR as a part of the release pipeline. Published images would now be available on ```mcr.microsoft.com/appsvc```