### PR TITLE
Optimized server params for PHP

### DIFF
--- a/GenerateDockerFiles/php/apache/Dockerfile
+++ b/GenerateDockerFiles/php/apache/Dockerfile
@@ -69,6 +69,8 @@ RUN rm -f /usr/local/etc/php/conf.d/php.ini \
 RUN rm -f /etc/apache2/conf-enabled/other-vhosts-access-log.conf
 RUN rm /etc/apache2/sites-enabled/000-default.conf
 
+COPY mpm_prefork.conf /etc/apache2/mods-available/mpm_prefork.conf
+
 WORKDIR /home/site/wwwroot
 
 ENTRYPOINT ["/bin/init_container.sh"]

--- a/GenerateDockerFiles/php/apache/init_container.sh
+++ b/GenerateDockerFiles/php/apache/init_container.sh
@@ -23,6 +23,22 @@ if [ "${WEBSITE_ENABLE_PHP_ACCESS_LOGS^^}" = TRUE ] ; then
 	sed -i "s/CustomLog \/dev\/null combined/CustomLog \/dev\/stderr combined/g" /etc/apache2/apache2.conf; 
 fi
 
+# Set default APACHE_SERVER_LIMIT if not provided by customer
+if [[ -z "${APACHE_SERVER_LIMIT}" ]]; then
+    APACHE_SERVER_LIMIT="1000"
+    export APACHE_SERVER_LIMIT="$APACHE_SERVER_LIMIT"
+fi
+
+# Set default APACHE_MAX_REQ_WORKERS if not provided by customer
+if [[ -z "${APACHE_MAX_REQ_WORKERS}" ]]; then
+    APACHE_MAX_REQ_WORKERS="256"
+    export APACHE_MAX_REQ_WORKERS="$APACHE_MAX_REQ_WORKERS"
+fi
+
+# Replace the values in mpm_prefork.conf for Apache to take them up
+sed -i "s/APACHE_SERVER_LIMIT/$APACHE_SERVER_LIMIT/g" /etc/apache2/mods-available/mpm_prefork.conf
+sed -i "s/APACHE_MAX_REQ_WORKERS/$APACHE_MAX_REQ_WORKERS/g" /etc/apache2/mods-available/mpm_prefork.conf
+
 # starting sshd process
 sed -i "s/SSH_PORT/$SSH_PORT/g" /etc/ssh/sshd_config
 /usr/sbin/sshd

--- a/GenerateDockerFiles/php/apache/mpm_prefork.conf
+++ b/GenerateDockerFiles/php/apache/mpm_prefork.conf
@@ -1,0 +1,17 @@
+# prefork MPM
+# StartServers: number of server processes to start
+# MinSpareServers: minimum number of server processes which are kept spare
+# MaxSpareServers: maximum number of server processes which are kept spare
+# MaxRequestWorkers: maximum number of server processes allowed to start
+# MaxConnectionsPerChild: maximum number of requests a server process serves
+
+<IfModule mpm_prefork_module>
+	StartServers			 5
+	MinSpareServers		  5
+	MaxSpareServers		 10
+	MaxRequestWorkers	  APACHE_MAX_REQ_WORKERS
+	MaxConnectionsPerChild   0
+	ServerLimit   APACHE_SERVER_LIMIT
+</IfModule>
+
+# vim: syntax=apache ts=4 sw=4 sts=4 sr noet


### PR DESCRIPTION
Setting ServerLimit = 1000 and MaxRequestWorkers = 256 which allows a PHP site like wordpress handle 1000 simultaneous users. These parameters can also be configured through app settings by the customer. 

The results and analysis has been put into [this OneNote.](https://microsoft.sharepoint.com/teams/Antares/_layouts/OneNote.aspx?id=%2Fteams%2FAntares%2FShared%20Documents%2FAntares%20Linux%20Engineering&wd=target%28PHP%20Improvements.one%7CEDA88B15-5DC5-4B3F-B8B0-95633E9492F3%2FPHP%20optimization%20analysis%7C8A1157BD-DDEB-499A-9E15-B7585B370929%2F%29
onenote:https://microsoft.sharepoint.com/teams/Antares/Shared%20Documents/Antares%20Linux%20Engineering/PHP%20Improvements.one#PHP%20optimization%20analysis&section-id={EDA88B15-5DC5-4B3F-B8B0-95633E9492F3}&page-id={8A1157BD-DDEB-499A-9E15-B7585B370929}&end)