### PR TITLE
dotnet fix CVE-2020-1967

### DIFF
--- a/GenerateDockerFiles/dotnetcore/debian-9/Dockerfile
+++ b/GenerateDockerFiles/dotnetcore/debian-9/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update \
         dnsutils \
         tcpdump \
         iproute2 \
+    && apt-get upgrade -y openssl \
     && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p /defaulthome/hostingstart \

--- a/localGenerateDockerFiles.sh
+++ b/localGenerateDockerFiles.sh
@@ -3,7 +3,7 @@
 # values from ImageBuilder/GenerateDockerFiles/dockerFilesGenerateTask.yml
 artifactStagingDirectory="output/DockerFiles"
 baseImageName="mcr.microsoft.com/oryx"
-baseImageVersion="20200312.1"
+baseImageVersion="20200429.2" # change me as needed
 appSvcGitUrl="https://github.com/Azure-App-Service"
 configDir="Config"
 


### PR DESCRIPTION
https://metadata.ftp-master.debian.org/changelogs/main/o/openssl/openssl_1.1.1d-0+deb10u3_changelog

<pre>root@ba542ec6a122:~/site/wwwroot# apt-cache policy openssl
openssl:
  Installed: 1.1.1d-0+deb10u3
  Candidate: 1.1.1d-0+deb10u3
  Version table:
 *** 1.1.1d-0+deb10u3 100
        100 /var/lib/dpkg/status
</pre>

still waiting for dotnet 3.1.4 to fix  CVE-2020-1161 