### PR TITLE
Change naming convention to antenv and initialize virtual env on ssh

### DIFF
--- a/GenerateDockerFiles/python/template-2.7/Dockerfile
+++ b/GenerateDockerFiles/python/template-2.7/Dockerfile
@@ -33,7 +33,7 @@ ENV SSH_PORT 2222
 RUN mkdir -p /home/LogFiles \
      && echo "root:Docker!" | chpasswd \
      && echo "cd /home" >> /root/.bashrc \
-     && echo "source /home/site/wwwroot/venv/bin/activate" >> /root/.bashrc
+     && echo "if [ -d \"/home/site/wwwroot/antenv2.7\" ]; then source /home/site/wwwroot/antenv2.7/bin/activate; elif [ -d \"/antenv2.7\" ]; then source /antenv2.7/bin/activate; fi" >> /root/.bashrc
 
 COPY sshd_config /etc/ssh/
 RUN mkdir -p /opt/startup

--- a/GenerateDockerFiles/python/template-2.7/init_container.sh
+++ b/GenerateDockerFiles/python/template-2.7/init_container.sh
@@ -17,9 +17,6 @@ Note: Any data outside '/home' is not persisted
 EOL
 cat /etc/motd
 
-# Create the virtual environment for python
-virtualenv /home/site/wwwroot/venv
-
 sed -i "s/SSH_PORT/$SSH_PORT/g" /etc/ssh/sshd_config
 service ssh start
 
@@ -29,7 +26,7 @@ eval $(printenv | sed -n "s/^\([^=]\+\)=\(.*\)$/export \1=\2/p" | sed 's/"/\\\"/
 echo "$@" > /opt/startup/startupCommand
 chmod 755 /opt/startup/startupCommand
  
-oryxArgs="create-script -appPath /home/site/wwwroot -output /opt/startup/startup.sh -virtualEnvName venv -defaultApp /opt/defaultsite -bindPort $PORT"
+oryxArgs="create-script -appPath /home/site/wwwroot -output /opt/startup/startup.sh -virtualEnvName antenv2.7 -defaultApp /opt/defaultsite -bindPort $PORT"
 if [ $# -eq 0 ]; then
     echo 'App Command Line not configured, will attempt auto-detect'
 else

--- a/GenerateDockerFiles/python/template-3.6/Dockerfile
+++ b/GenerateDockerFiles/python/template-3.6/Dockerfile
@@ -32,7 +32,7 @@ ENV SSH_PORT 2222
 RUN mkdir -p /home/LogFiles \
      && echo "root:Docker!" | chpasswd \
      && echo "cd /home" >> /root/.bashrc \
-     && echo "source /home/site/wwwroot/venv/bin/activate" >> /root/.bashrc
+     && echo "if [ -d \"/home/site/wwwroot/antenv3.6\" ]; then source /home/site/wwwroot/antenv3.6/bin/activate; elif [ -d \"/antenv3.6\" ]; then source /antenv3.6/bin/activate; fi" >> /root/.bashrc
 
 COPY sshd_config /etc/ssh/
 RUN mkdir -p /opt/startup

--- a/GenerateDockerFiles/python/template-3.6/init_container.sh
+++ b/GenerateDockerFiles/python/template-3.6/init_container.sh
@@ -17,9 +17,6 @@ Note: Any data outside '/home' is not persisted
 EOL
 cat /etc/motd
 
-# Create the virtual environment for python
-python3 -m venv /home/site/wwwroot/venv
-
 sed -i "s/SSH_PORT/$SSH_PORT/g" /etc/ssh/sshd_config
 service ssh start
 
@@ -29,7 +26,7 @@ eval $(printenv | sed -n "s/^\([^=]\+\)=\(.*\)$/export \1=\2/p" | sed 's/"/\\\"/
 echo "$@" > /opt/startup/startupCommand
 chmod 755 /opt/startup/startupCommand
 
-oryxArgs="create-script -appPath /home/site/wwwroot -output /opt/startup/startup.sh -virtualEnvName venv -defaultApp /opt/defaultsite -bindPort $PORT"
+oryxArgs="create-script -appPath /home/site/wwwroot -output /opt/startup/startup.sh -virtualEnvName antenv3.6 -defaultApp /opt/defaultsite -bindPort $PORT"
 if [ $# -eq 0 ]; then
     echo 'App Command Line not configured, will attempt auto-detect'
 else

--- a/GenerateDockerFiles/python/template-3.7/Dockerfile
+++ b/GenerateDockerFiles/python/template-3.7/Dockerfile
@@ -32,7 +32,7 @@ ENV SSH_PORT 2222
 RUN mkdir -p /home/LogFiles \
      && echo "root:Docker!" | chpasswd \
      && echo "cd /home" >> /root/.bashrc \
-     && echo "source /home/site/wwwroot/venv/bin/activate" >> /root/.bashrc  
+     && echo "if [ -d \"/home/site/wwwroot/antenv\" ]; then source /home/site/wwwroot/antenv/bin/activate; elif [ -d \"/antenv\" ]; then source /antenv/bin/activate; fi" >> /root/.bashrc 
      
 COPY sshd_config /etc/ssh/
 RUN mkdir -p /opt/startup

--- a/GenerateDockerFiles/python/template-3.7/init_container.sh
+++ b/GenerateDockerFiles/python/template-3.7/init_container.sh
@@ -17,9 +17,6 @@ Note: Any data outside '/home' is not persisted
 EOL
 cat /etc/motd
 
-# Create the virtual environment for python
-python3 -m venv /home/site/wwwroot/venv
-
 sed -i "s/SSH_PORT/$SSH_PORT/g" /etc/ssh/sshd_config
 service ssh start
 
@@ -29,7 +26,7 @@ eval $(printenv | sed -n "s/^\([^=]\+\)=\(.*\)$/export \1=\2/p" | sed 's/"/\\\"/
 echo "$@" > /opt/startup/startupCommand
 chmod 755 /opt/startup/startupCommand
 
-oryxArgs="create-script -appPath /home/site/wwwroot -output /opt/startup/startup.sh -virtualEnvName venv -defaultApp /opt/defaultsite -bindPort $PORT"
+oryxArgs="create-script -appPath /home/site/wwwroot -output /opt/startup/startup.sh -virtualEnvName antenv -defaultApp /opt/defaultsite -bindPort $PORT"
 if [ $# -eq 0 ]; then
     echo 'App Command Line not configured, will attempt auto-detect'
 else

--- a/GenerateDockerFiles/python/template-3.8/Dockerfile
+++ b/GenerateDockerFiles/python/template-3.8/Dockerfile
@@ -32,7 +32,7 @@ ENV SSH_PORT 2222
 RUN mkdir -p /home/LogFiles \
      && echo "root:Docker!" | chpasswd \
      && echo "cd /home" >> /root/.bashrc \
-     && echo "source /home/site/wwwroot/venv/bin/activate" >> /root/.bashrc
+     && echo "if [ -d \"/home/site/wwwroot/antenv\" ]; then source /home/site/wwwroot/antenv/bin/activate; elif [ -d \"/antenv\" ]; then source /antenv/bin/activate; fi" >> /root/.bashrc
      
 COPY sshd_config /etc/ssh/
 RUN mkdir -p /opt/startup

--- a/GenerateDockerFiles/python/template-3.8/init_container.sh
+++ b/GenerateDockerFiles/python/template-3.8/init_container.sh
@@ -17,9 +17,6 @@ Note: Any data outside '/home' is not persisted
 EOL
 cat /etc/motd
 
-# Create the virtual environment for python
-python3 -m venv /home/site/wwwroot/venv
-
 sed -i "s/SSH_PORT/$SSH_PORT/g" /etc/ssh/sshd_config
 service ssh start
 
@@ -29,7 +26,7 @@ eval $(printenv | sed -n "s/^\([^=]\+\)=\(.*\)$/export \1=\2/p" | sed 's/"/\\\"/
 echo "$@" > /opt/startup/startupCommand
 chmod 755 /opt/startup/startupCommand
 
-oryxArgs='create-script -appPath /home/site/wwwroot -output /opt/startup/startup.sh -virtualEnvName venv -defaultApp /opt/defaultsite'
+oryxArgs='create-script -appPath /home/site/wwwroot -output /opt/startup/startup.sh -virtualEnvName antenv -defaultApp /opt/defaultsite'
 if [ $# -eq 0 ]; then
     echo 'App Command Line not configured, will attempt auto-detect'
 else


### PR DESCRIPTION
Check if virtual env given by user and activate it on ssh. Else, activate the virtual env created by Kudu. naming conventions followed for virtual environment activation either way are - 
Python 2.7 - antenv2.7
Python 3.6 - antenv3.6
Python 3.7 onwards - antenv