### PR TITLE
Support for trigger profiling in xdebug

### DIFF
--- a/GenerateDockerFiles/php/apache/init_container.sh
+++ b/GenerateDockerFiles/php/apache/init_container.sh
@@ -18,6 +18,15 @@ cat /etc/motd
 # Get environment variables to show up in SSH session
 eval $(printenv | sed -n "s/^\([^=]\+\)=\(.*\)$/export \1=\2/p" | sed 's/"/\\\"/g' | sed '/=/s//="/' | sed 's/$/"/' >> /etc/profile)
 
+# Enable trigger profiling in xdebug
+if [ "${WEBSITE_PROFILER_ENABLE_TRIGGER^^}" = TRUE ] ; then 
+  echo 'xdebug.profiler_enable_trigger=1' >> /usr/local/etc/php/conf.d/php.ini;
+  echo 'xdebug.profiler_enable=0' >> /usr/local/etc/php/conf.d/php.ini;
+else
+  sed -i "s/xdebug.profiler_enable_trigger=1//g" /usr/local/etc/php/conf.d/php.ini
+  sed -i "s/xdebug.profiler_enable=0//g" /usr/local/etc/php/conf.d/php.ini
+fi
+
 # redirect php custom logs to stderr
 if [ "${WEBSITE_ENABLE_PHP_ACCESS_LOGS^^}" = TRUE ] ; then 
 	sed -i "s/CustomLog \/dev\/null combined/CustomLog \/dev\/stderr combined/g" /etc/apache2/apache2.conf; 


### PR DESCRIPTION
If WEBSITE_PROFILER_ENABLE_TRIGGER is set to TRUE, it configures trigger profiling on xdebug. This allows you to trigger profiling by sending a POST parameter or by setting an XDEBUG_PROFILE cookie. Numerous browser extensions can be used to trigger profile.