### PR TITLE
Turn of "EnableMMAP" for PHP images

### DIFF
--- a/GenerateDockerFiles/php/apache/Dockerfile
+++ b/GenerateDockerFiles/php/apache/Dockerfile
@@ -55,6 +55,7 @@ RUN { \
    echo '<FilesMatch "\.(?i:ph([[p]?[0-9]*|tm[l]?))$">'; \
    echo '   SetHandler application/x-httpd-php'; \
    echo '</FilesMatch>'; \
+   echo 'EnableMMAP Off'; \
 } >> /etc/apache2/apache2.conf
 
 RUN rm -f /usr/local/etc/php/conf.d/php.ini \


### PR DESCRIPTION
For 18.04 on VMSS we found that static files served from a cifs share would be corrupted and cause an error where the front end could not understand the response and returned a 504. 

Scenarios tested:
18.04 on Cloud Services
18.04 on VMSS