### PR TITLE
Fix ssh-keygen type for ecdsa & ed25519

### DIFF
--- a/GenerateDockerFiles/dotnetcore/debian-9/ssh_setup.sh
+++ b/GenerateDockerFiles/dotnetcore/debian-9/ssh_setup.sh
@@ -12,12 +12,12 @@ fi
 
 if [ ! -f "/etc/ssh/ssh_host_ecdsa_key" ]; then
   # generate fresh ecdsa key
-  ssh-keygen -f /etc/ssh/ssh_host_ecdsa_key -N '' -t dsa
+  ssh-keygen -f /etc/ssh/ssh_host_ecdsa_key -N '' -t ecdsa
 fi
 
 if [ ! -f "/etc/ssh/ssh_host_ed25519_key" ]; then
   # generate fresh ecdsa key
-  ssh-keygen -f /etc/ssh/ssh_host_ed25519_key -N '' -t dsa
+  ssh-keygen -f /etc/ssh/ssh_host_ed25519_key -N '' -t ed25519
 fi
 
 #prepare run dir

--- a/GenerateDockerFiles/node/node-template/ssh_setup.sh
+++ b/GenerateDockerFiles/node/node-template/ssh_setup.sh
@@ -12,12 +12,12 @@ fi
 
 if [ ! -f "/etc/ssh/ssh_host_ecdsa_key" ]; then
   # generate fresh ecdsa key
-  ssh-keygen -f /etc/ssh/ssh_host_ecdsa_key -N '' -t dsa
+  ssh-keygen -f /etc/ssh/ssh_host_ecdsa_key -N '' -t ecdsa
 fi
 
 if [ ! -f "/etc/ssh/ssh_host_ed25519_key" ]; then
   # generate fresh ecdsa key
-  ssh-keygen -f /etc/ssh/ssh_host_ed25519_key -N '' -t dsa
+  ssh-keygen -f /etc/ssh/ssh_host_ed25519_key -N '' -t ed25519
 fi
 
 #prepare run dir

--- a/GenerateDockerFiles/node/pm2-template/ssh_setup.sh
+++ b/GenerateDockerFiles/node/pm2-template/ssh_setup.sh
@@ -12,12 +12,12 @@ fi
 
 if [ ! -f "/etc/ssh/ssh_host_ecdsa_key" ]; then
   # generate fresh ecdsa key
-  ssh-keygen -f /etc/ssh/ssh_host_ecdsa_key -N '' -t dsa
+  ssh-keygen -f /etc/ssh/ssh_host_ecdsa_key -N '' -t ecdsa
 fi
 
 if [ ! -f "/etc/ssh/ssh_host_ed25519_key" ]; then
   # generate fresh ecdsa key
-  ssh-keygen -f /etc/ssh/ssh_host_ed25519_key -N '' -t dsa
+  ssh-keygen -f /etc/ssh/ssh_host_ed25519_key -N '' -t ed25519
 fi
 
 #prepare run dir

--- a/GenerateDockerFiles/php/apache/ssh_setup.sh
+++ b/GenerateDockerFiles/php/apache/ssh_setup.sh
@@ -12,12 +12,12 @@ fi
 
 if [ ! -f "/etc/ssh/ssh_host_ecdsa_key" ]; then
   # generate fresh ecdsa key
-  ssh-keygen -f /etc/ssh/ssh_host_ecdsa_key -N '' -t dsa
+  ssh-keygen -f /etc/ssh/ssh_host_ecdsa_key -N '' -t ecdsa
 fi
 
 if [ ! -f "/etc/ssh/ssh_host_ed25519_key" ]; then
   # generate fresh ecdsa key
-  ssh-keygen -f /etc/ssh/ssh_host_ed25519_key -N '' -t dsa
+  ssh-keygen -f /etc/ssh/ssh_host_ed25519_key -N '' -t ed25519
 fi
 
 #prepare run dir


### PR DESCRIPTION
Fix the ecdsa and ed25519 keygen, currently incorrectly dsa type.