### PR TITLE
update node image builder's init script

### DIFF
--- a/GenerateDockerFiles/node/node-template/startup/init_container.sh
+++ b/GenerateDockerFiles/node/node-template/startup/init_container.sh
@@ -31,9 +31,9 @@ STARTUP_COMMAND_PATH="/opt/startup/startup.sh"
 ORYX_ARGS="create-script -appPath /home/site/wwwroot -output $STARTUP_COMMAND_PATH -defaultApp=/opt/startup/default-static-site.js -userStartupCommand '$@'"
 
 if [[ $APPSVC_REMOTE_DEBUGGING == "TRUE" ]]; then
-    ORYX_ARGS="-remoteDebug -debugPort $APPSVC_TUNNEL_PORT $ORYX_ARGS"
+    ORYX_ARGS="$ORYX_ARGS -remoteDebug -debugPort $APPSVC_TUNNEL_PORT"
 elif [[ "$APPSVC_REMOTE_DEBUGGING_BREAK" == "TRUE" ]]; then
-    ORYX_ARGS="-remoteDebugBrk -debugPort $APPSVC_TUNNEL_PORT $ORYX_ARGS"
+    ORYX_ARGS="$ORYX_ARGS -remoteDebugBrk -debugPort $APPSVC_TUNNEL_PORT"
 fi
 
 if [ -f "oryx-manifest.toml" ] && [[ "$APPSVC_RUN_ZIP" == "TRUE" ]]; then

--- a/GenerateDockerFiles/node/pm2-template/startup/init_container.sh
+++ b/GenerateDockerFiles/node/pm2-template/startup/init_container.sh
@@ -31,9 +31,9 @@ STARTUP_COMMAND_PATH="/opt/startup/startup.sh"
 ORYX_ARGS="create-script -appPath /home/site/wwwroot -output $STARTUP_COMMAND_PATH -usePM2 -defaultApp=/opt/startup/default-static-site.js -userStartupCommand '$@'"
 
 if [[ $APPSVC_REMOTE_DEBUGGING == "TRUE" ]]; then
-    ORYX_ARGS="-remoteDebug -debugPort $APPSVC_TUNNEL_PORT $ORYX_ARGS"
+    ORYX_ARGS="$ORYX_ARGS -remoteDebug -debugPort $APPSVC_TUNNEL_PORT"
 elif [[ "$APPSVC_REMOTE_DEBUGGING_BREAK" == "TRUE" ]]; then
-    ORYX_ARGS="-remoteDebugBrk -debugPort $APPSVC_TUNNEL_PORT $ORYX_ARGS"
+    ORYX_ARGS="$ORYX_ARGS -remoteDebugBrk -debugPort $APPSVC_TUNNEL_PORT"
 fi
 
 if [ -f "oryx-manifest.toml" ] && [[ "$APPSVC_RUN_ZIP" == "TRUE" ]]; then


### PR DESCRIPTION
Seems like the way we  were concatenating oryx_args in the init_containerscript is causing problem.
For example a correct eval on oryx create-script command with debugging will be something like this
oryx create-script -remoteDebugBrk -appPath /tmp/app -output /tmp/app/run.sh-debugPort=8080

Currently, it is generating the command as  oryx -remoteDebugBrk -debugPort=8080 create-script -appPath /tmp/app -output /tmp/app/run.sh

Because of this we are seeing following errors while debugging via vs-code

- flag provided but not defined: -remoteDebugBrk
- flag provided but not defined: -remoteDebug