### PR TITLE
KuduBuild Bug Fixes

### DIFF
--- a/CI.yml
+++ b/CI.yml
@@ -169,7 +169,7 @@ jobs:
     parameters:
       stackName: KuduLite
       filesRootPath: GitRepo-DynInst
-      imgTag: dynamic-$(Build.BuildNumber)
+      imgTag: dynamic_$(Build.BuildNumber)
 
 - job: Job_BuildStaticSiteImage
   displayName: Build Static Site Dev Images

--- a/GenerateDockerFiles/KuduLite/template/kudu/Dockerfile
+++ b/GenerateDockerFiles/KuduLite/template/kudu/Dockerfile
@@ -137,6 +137,7 @@ RUN ln -s /opt/nodejs/9/lib/node_modules/npm/bin/npm-cli.js /usr/bin/npm-cli.js
 ENV PATH=$PATH:/opt/nodejs/9/bin
 
 ENV KUDU_WEBSSH_PORT=3000
+ENV KUDU_BUILD_VERSION=0.0.1
 
 # Default App Settings for Main App Container SSH
 ENV WEBSITE_SSH_USER=root

--- a/GenerateDockerFiles/KuduLite/template_dynamicinstalls/kudu/Dockerfile
+++ b/GenerateDockerFiles/KuduLite/template_dynamicinstalls/kudu/Dockerfile
@@ -56,10 +56,11 @@ RUN mkdir /opt/webssh \
   && chmod 755 /usr/bin/tcpping \
 # Enable SSH for Kudu Console
   && apt-get install -y ssh \
+# Replace ssh with wrapper script for CIFS mount permissions workaround
+  && mv /usr/bin/ssh /usr/bin/ssh.original \
   && mv /tmp/ssh /usr/bin/ssh \
   && chown root:root /usr/bin/ssh \
   && chmod 755 /usr/bin/ssh \
-  && echo "root:Docker!" | chpasswd \
   && sed -i '/^#Port* /s/^#//' /etc/ssh/sshd_config \
   && sed -i '/^#PermitRootLogin* /s/^#PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config \
   && sed -i '/^#PrintLastLog* /s/^#PrintLastLog yes/PrintLastLog no/' /etc/ssh/sshd_config \
@@ -72,8 +73,6 @@ RUN mkdir /opt/webssh \
   && apt-get  install -y unzip --no-install-recommends \
 # Install pm2 and pm2-logrotate
   && mkdir -p /home/LogFiles \
-# Replace ssh with wrapper script for CIFS mount permissions workaround
-  && mv /usr/bin/ssh /usr/bin/ssh.original \
   && chmod -R 777 /home \
   && rm -rf /tmp/* \
   && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
This PR fixes:
1. SSH based private gt pulls failing with dynamic kudu due to wrapper ssh script wrongly named
2. Naming of dynamic kudu image to have `_` instead of `-`
3. Ensures hot patched var `KUDU_BUILD_VERSION` is present