### PR TITLE
Add azcopy to KuduLite and dotnetcore

### DIFF
--- a/GenerateDockerFiles/KuduLite/template/kudu/Dockerfile
+++ b/GenerateDockerFiles/KuduLite/template/kudu/Dockerfile
@@ -72,6 +72,9 @@ RUN apt-get update \
     clamav=0.102.3+dfsg-0~deb9u1 \
   && freshclam
 
+# Install azcopy
+RUN curl -L https://aka.ms/downloadazcopy-v10-linux | tar -C /usr/local/bin -xzf - --strip-components=1
+
 # Enable SSH for Kudu Console
 RUN apt-get install -y ssh \
    && sed -i '/^#Port* /s/^#//' /etc/ssh/sshd_config \

--- a/GenerateDockerFiles/dotnetcore/debian-9/Dockerfile
+++ b/GenerateDockerFiles/dotnetcore/debian-9/Dockerfile
@@ -18,6 +18,8 @@ RUN apt-get update \
     && apt-get upgrade -y openssl \
     && rm -rf /var/lib/apt/lists/*
 
+RUN curl -L https://aka.ms/downloadazcopy-v10-linux | tar -C /usr/local/bin -xzf - --strip-components=1
+
 RUN mkdir -p /defaulthome/hostingstart \
     && mkdir -p /home/LogFiles/ \
     && echo "root:Docker!" | chpasswd \


### PR DESCRIPTION
This PR adds the azcopy binary to /usr/local/bin of KuduLite and dotnetcore images. This will help customers easily transfer files to and from blob. A typical usage is to upload dump files taken in a container to blob.