### PR TITLE
Add no-auth switch to dotnet-monitor

### DIFF
--- a/GenerateDockerFiles/dotnetcore/debian-9/init_container.sh
+++ b/GenerateDockerFiles/dotnetcore/debian-9/init_container.sh
@@ -46,7 +46,7 @@ if [ "$APP_SVC_RUN_FROM_COPY" = true ]; then
 fi
 
 if [ "$USE_DOTNET_MONITOR" = true ]; then
-    /opt/dotnetcore-tools/dotnet-monitor collect --urls "http://0.0.0.0:50051" --metrics true --metricUrls "http://0.0.0.0:50050" > /dev/null 2>&1 &
+    /opt/dotnetcore-tools/dotnet-monitor collect --urls "http://0.0.0.0:50051" --metrics true --metricUrls "http://0.0.0.0:50050" --no-auth > /dev/null 2>&1 &
 fi
 
 oryxArgs="create-script -appPath $appPath -output $startupCommandPath -defaultAppFilePath $defaultAppPath \


### PR DESCRIPTION
Adding --no-auth switch as the tool seems to be upgraded to the latest one and is throwing a 401 error when called from Process Explorer UI.