### PR TITLE
Visaayir/remove gunicorn pidfile

### DIFF
--- a/GenerateDockerFiles/python/template-2.7/Dockerfile
+++ b/GenerateDockerFiles/python/template-2.7/Dockerfile
@@ -24,8 +24,7 @@ RUN apt-get update \
     && pip install gunicorn \ 
     && pip install virtualenv \
     && pip install flask \
-    && pip install scandir \
-    && pip install pathlib2
+    && pip install scandir 
 
 WORKDIR ${HOME_SITE}
 

--- a/GenerateDockerFiles/python/template-2.7/gunicorn.conf.py
+++ b/GenerateDockerFiles/python/template-2.7/gunicorn.conf.py
@@ -1,26 +1,4 @@
-import threading
-import os
 import appServiceAppLogs as asal
-
-from pathlib2 import Path
-
-# For python version > 3.6, the following constants are dervied from appsvc_profiler package.
-# viztracer doesnt support Python 2.7
-# Hence appsvc_profiler which wraps around viztracer cannot be instead. 
-INSTANCE_ID_ENV_NAME = "WEBSITE_INSTANCE_ID"
-def get_instance_id_trimmed():
-    instance_id = os.getenv(INSTANCE_ID_ENV_NAME,"default")
-    return instance_id[:6]
-
-CODE_PROFILER_LOGS_DIR = "/home/LogFiles/CodeProfiler"
-PID_FILE_LOCATION = CODE_PROFILER_LOGS_DIR+"/"+get_instance_id_trimmed()+"_master_process.pid"
-
-try:
-    Path(CODE_PROFILER_LOGS_DIR).mkdir(parents=True, exist_ok=True)    
-    pidfile = PID_FILE_LOCATION
-    
-except Exception as e:
-    print( "Gunicorn was unable to set the pidfile path due to the exception : " + e )
 
 def on_starting(server):
     asal.initAppLogs()

--- a/GenerateDockerFiles/python/template-3.6/gunicorn.conf.py
+++ b/GenerateDockerFiles/python/template-3.6/gunicorn.conf.py
@@ -1,26 +1,4 @@
-import threading
-import os
 import appServiceAppLogs as asal
-
-from pathlib import Path
-
-# For python version > 3.6, the following constants are dervied from appsvc_profiler package.
-# Oryx has issues installing viztracer for Python 3.6
-# Hence appsvc_profiler which wraps around viztracer cannot be instead. 
-INSTANCE_ID_ENV_NAME = "WEBSITE_INSTANCE_ID"
-def get_instance_id_trimmed():
-    instance_id = os.getenv(INSTANCE_ID_ENV_NAME,"default")
-    return instance_id[:6]
-
-CODE_PROFILER_LOGS_DIR = "/home/LogFiles/CodeProfiler"
-PID_FILE_LOCATION = f"{CODE_PROFILER_LOGS_DIR}/{get_instance_id_trimmed()}_master_process.pid"
-
-try:
-    Path(CODE_PROFILER_LOGS_DIR).mkdir(parents=True, exist_ok=True)
-    pidfile = PID_FILE_LOCATION
-    
-except Exception as e:
-    print(f"Gunicorn was unable to set the pidfile path due to the exception : {e}")
 
 def on_starting(server):
     asal.initAppLogs()

--- a/GenerateDockerFiles/python/template-3.7/gunicorn.conf.py
+++ b/GenerateDockerFiles/python/template-3.7/gunicorn.conf.py
@@ -1,18 +1,7 @@
-import os
+import appServiceAppLogs as asal
 
 # appsvc_profiler is currenly installed from appsvc_code_profiler-1.0.0-py3-none-any.whl
 from appsvc_profiler import CodeProfilerInstaller
-from appsvc_profiler.constants import CodeProfilerConstants
-from pathlib import Path
-import appServiceAppLogs as asal
-
-try:
-    constants = CodeProfilerConstants()
-    Path(constants.CODE_PROFILER_LOGS_DIR).mkdir(parents=True, exist_ok=True)
-    pidfile = constants.PID_FILE_LOCATION
-    
-except Exception as e:
-    print(f"Gunicorn was unable to set the pidfile path due to the exception : {e}")
 
 def post_worker_init(worker):
     asal.startHandlerRegisterer()

--- a/GenerateDockerFiles/python/template-3.8/gunicorn.conf.py
+++ b/GenerateDockerFiles/python/template-3.8/gunicorn.conf.py
@@ -1,18 +1,7 @@
-import os
+import appServiceAppLogs as asal
 
 # appsvc_profiler is currenly installed from appsvc_code_profiler-1.0.0-py3-none-any.whl
 from appsvc_profiler import CodeProfilerInstaller
-from appsvc_profiler.constants import CodeProfilerConstants
-from pathlib import Path
-import appServiceAppLogs as asal
-
-try:
-    constants = CodeProfilerConstants()
-    Path(constants.CODE_PROFILER_LOGS_DIR).mkdir(parents=True, exist_ok=True)
-    pidfile = constants.PID_FILE_LOCATION
-    
-except Exception as e:
-    print(f"Gunicorn was unable to set the pidfile path due to the exception : {e}")
 
 def post_worker_init(worker):
     asal.startHandlerRegisterer()

--- a/GenerateDockerFiles/python/template-3.9/gunicorn.conf.py
+++ b/GenerateDockerFiles/python/template-3.9/gunicorn.conf.py
@@ -1,5 +1,6 @@
-# appsvc_profiler is currenly installed from appsvc_code_profiler-1.0.0-py3-none-any.whl
 import appServiceAppLogs as asal
+
+# appsvc_profiler is currenly installed from appsvc_code_profiler-1.0.0-py3-none-any.whl
 from appsvc_profiler import CodeProfilerInstaller
 
 def post_worker_init(worker):

--- a/GenerateDockerFiles/python/template-3.9/gunicorn.conf.py
+++ b/GenerateDockerFiles/python/template-3.9/gunicorn.conf.py
@@ -1,18 +1,6 @@
-import os
-
 # appsvc_profiler is currenly installed from appsvc_code_profiler-1.0.0-py3-none-any.whl
-from appsvc_profiler import CodeProfilerInstaller
-from appsvc_profiler.constants import CodeProfilerConstants
-from pathlib import Path
 import appServiceAppLogs as asal
-
-try:
-    constants = CodeProfilerConstants()
-    Path(constants.CODE_PROFILER_LOGS_DIR).mkdir(parents=True, exist_ok=True)
-    pidfile = constants.PID_FILE_LOCATION
-    
-except Exception as e:
-    print(f"Gunicorn was unable to set the pidfile path due to the exception : {e}")
+from appsvc_profiler import CodeProfilerInstaller
 
 def post_worker_init(worker):
     asal.startHandlerRegisterer()


### PR DESCRIPTION
Setting gunicorn pidfile intermittently causes site startup issues.
To avoid this Diagnostic server removed the dependency on pidfile. 
Since we no longer need to set the pidfile, removing the code references.