### PR TITLE
Removing weekly builds for releases/* branch

### DIFF
--- a/CI.yml
+++ b/CI.yml
@@ -14,12 +14,6 @@ schedules:
     exclude:
     - releases/*
     - releases/ancient/*
-- cron: "0 12 * * 0"
-  displayName: Weekly Sunday build
-  branches:
-    include:
-    - releases/*
-  always: true
 
 jobs:
 


### PR DESCRIPTION
Removing weekly builds for releases/* branch

This is because releases/* branch contains commits that are cherry picked from master branch. We can run the pipeline for this branch manually ( whenever needed)