### PR TITLE
Fixing Url in Ruby Template to ensure that the pipeline succeeds

### DIFF
--- a/GenerateDockerFiles/ruby/template/Dockerfile
+++ b/GenerateDockerFiles/ruby/template/Dockerfile
@@ -108,8 +108,8 @@ RUN wget http://ftp.us.debian.org/debian/pool/main/o/openssl1.0/libssl1.0.2_1.0.
   && dpkg -i libssl1.0.2_1.0.2u-1~deb9u1_amd64.deb \
   && wget http://ftp.us.debian.org/debian/pool/main/libx/libxcrypt/libcrypt1-udeb_4.4.18-4_amd64.udeb \
   && dpkg -i libcrypt1-udeb_4.4.18-4_amd64.udeb \
-  && wget http://http.us.debian.org/debian/pool/main/g/glibc/libc6-udeb_2.28-10_amd64.udeb \
-  && dpkg -i --force-overwrite libc6-udeb_2.28-10_amd64.udeb \
+  && wget http://http.us.debian.org/debian/pool/main/g/glibc/libc6-udeb_2.28-10+deb10u1_amd64.udeb \
+  && dpkg -i --force-overwrite libc6-udeb_2.28-10+deb10u1_amd64.udeb \
   && wget http://ftp.us.debian.org/debian/pool/main/o/openssl/libcrypto1.1-udeb_1.1.0l-1~deb9u1_amd64.udeb \
   && dpkg -i --force-overwrite libcrypto1.1-udeb_1.1.0l-1~deb9u1_amd64.udeb \
   && wget http://ftp.us.debian.org/debian/pool/main/o/openssl/libssl1.1-udeb_1.1.0l-1~deb9u1_amd64.udeb \


### PR DESCRIPTION
ImageBuilder pipeline is broken because Ruby docker file makes call to
http://http.us.debian.org/debian/pool/main/g/glibc/libc6-udeb_2.28-10_amd64.udeb

This returns HTTP 404.

from Debain site I see that the url has been updated to
http://http.us.debian.org/debian/pool/main/g/glibc/libc6-udeb_2.28-10+deb10u1_arm64.udeb

Raising this PR to fix this