### PR TITLE
Updating oryx base image tag to 20220323.2

### DIFF
--- a/CI.yml
+++ b/CI.yml
@@ -172,6 +172,7 @@ jobs:
 - job: Job_DockerBuildWordPressImages
   displayName: Build WordPress Dev Images
   dependsOn: Job_GenerateDockerFiles
+  condition: and(succeeded(), eq(startsWith(variables['Build.SourceBranch'], 'refs/heads/releases/'), 'false'))
   pool:
     vmImage: ubuntu-18.04
   timeoutInMinutes: 100

--- a/CI.yml
+++ b/CI.yml
@@ -172,7 +172,7 @@ jobs:
 - job: Job_DockerBuildWordPressImages
   displayName: Build WordPress Dev Images
   dependsOn: Job_GenerateDockerFiles
-  condition: and(succeeded(), eq(startsWith(variables['Build.SourceBranch'], 'refs/heads/releases/'), 'false'))
+  condition: and(succeeded(), not(startsWith(variables['Build.SourceBranch'], 'refs/heads/releases/')))
   pool:
     vmImage: ubuntu-18.04
   timeoutInMinutes: 100

--- a/GenerateDockerFiles/dockerFilesGenerateTask.yml
+++ b/GenerateDockerFiles/dockerFilesGenerateTask.yml
@@ -2,7 +2,7 @@ parameters:
   ascName: WAWS_Container_Images
   acrName: wawsimages.azurecr.io
   baseImageName: "mcr.microsoft.com/oryx"
-  baseImageVersion: "20211120.1"
+  baseImageVersion: "20220323.2"
   appSvcGitUrl: "https://github.com/Azure-App-Service"
   kuduliteInternalRepo: $(KUDU_REPO)
 

--- a/localGenerateDockerFiles.sh
+++ b/localGenerateDockerFiles.sh
@@ -3,7 +3,7 @@
 # values from ImageBuilder/GenerateDockerFiles/dockerFilesGenerateTask.yml
 artifactStagingDirectory="output/DockerFiles"
 baseImageName="mcr.microsoft.com/oryx"
-baseImageVersion="20211120.1" # change me as needed
+baseImageVersion="20220323.2" # change me as needed
 appSvcGitUrl="https://github.com/Azure-App-Service"
 configDir="Config"
 


### PR DESCRIPTION
Updating the base image for Oryx which contains security patches for latest .net image versions

In this PR I am also including commit 97acf53732d9fa2ebf09ed290811b0d809a97a5b from PR https://github.com/Azure-App-Service/ImageBuilder/pull/229. This is to avoid retagging of Wordpress images with Older code
