### PR TITLE
Adding Kudulite Hot Patch pipeline

### DIFF
--- a/Kudulite-HotPatch/CI/Kudulite-HotPatch.yaml
+++ b/Kudulite-HotPatch/CI/Kudulite-HotPatch.yaml
@@ -1,0 +1,50 @@
+resources:
+- repo: self
+  fetchDepth: 15
+
+variables:
+- group: AppServiceLinux
+
+jobs:
+- job: Job_CleanUp
+  displayName: Clean Machine
+  pool:
+    vmImage: ubuntu-18.04
+  timeoutInMinutes: 150
+  steps:
+  - template: CleanUp/cleanImageCache.yml
+
+- job: Job_GenerateDockerFiles
+  displayName: Generate DockerFiles
+  dependsOn: Job_CleanUp
+  pool:
+    vmImage: ubuntu-18.04
+  timeoutInMinutes: 100
+  steps:
+  - script: |
+      echo "##vso[task.setvariable variable=InitialChecks;]true"
+      echo "##vso[task.setvariable variable=GenerateDockerFiles;]false"
+      echo "##vso[task.setvariable variable=BuildBuildImages;]false"
+      echo "##vso[task.setvariable variable=PushBuildImages;]false"
+      echo "##vso[task.setvariable variable=PushRuntimeImages;]false"
+    displayName: 'Generate Dockerfile for Kudulite HotPatch'
+  - template: Kudulite-HotPatch/CI/generateKuduliteHotPatchImageDockerfileJob.yaml
+
+- job: Job_BuildKuduLiteImage
+  displayName: Build KuduLite Dev Images
+  dependsOn: Job_GenerateDockerFiles
+  pool:
+    vmImage: ubuntu-18.04
+  timeoutInMinutes: 100
+  steps:
+  - script: |
+      echo "##vso[task.setvariable variable=InitialChecks;]true"
+      echo "##vso[task.setvariable variable=GenerateDockerFiles;]true"
+      echo "##vso[task.setvariable variable=BuildBuildImages;]true"
+      echo "##vso[task.setvariable variable=PushBuildImages;]true"
+      echo "##vso[task.setvariable variable=PushRuntimeImages;]false"
+  - template: Kudulite-HotPatch/CI/buildKuduliteHotPatchImageJob.yaml
+    parameters:
+      stackName: KuduLite
+
+trigger: none

--- a/Kudulite-HotPatch/CI/buildKuduliteHotPatchImageJob.yml
+++ b/Kudulite-HotPatch/CI/buildKuduliteHotPatchImageJob.yml
@@ -1,0 +1,58 @@
+parameters:
+  ascName: WAWS_Container_Images
+  acrName: wawsimages.azurecr.io
+  stackName: ""
+  imgTag: "$(Build.BuildNumber)"
+  filesRootPath: "GitRepo"
+
+steps:
+- script: |
+    if [ "$(InitialChecks)" != "true" ]
+    then
+      echo "Invalid configuration."
+      echo "Variable 'InitialChecks' needs to be 'true' to run this build."
+      exit 1
+    fi
+  displayName: 'Validate pipeline run'
+
+- task: Docker@2
+  displayName: Logout of ACR
+  inputs:
+    command: logout
+    azureSubscriptionEndpoint: ${{ parameters.ascName }}
+    azureContainerRegistry: ${{ parameters.acrName }}
+
+- task: Docker@1
+  displayName: Container registry login
+  inputs:
+    command: login
+    azureSubscriptionEndpoint: ${{ parameters.ascName }}
+    azureContainerRegistry: ${{ parameters.acrName }}
+
+- task: DownloadBuildArtifacts@0
+  displayName: 'Download Build Artifacts'
+  inputs:
+    artifactName: drop
+
+- task: ShellScript@2
+  displayName: 'Build Images'
+  inputs:
+    scriptPath: ./Kudulite-HotPatch/Scripts/buildKuduliteHotPatchImages.sh
+    args: $(Build.ArtifactStagingDirectory)/drop appsvctest $(System.DefaultWorkingDirectory)/Config $(Build.BuildNumber) ${{ parameters.stackName }} $(Build.Reason) ${{ parameters.filesRootPath }} ${{ parameters.imgTag }}
+
+# Publish Build Artifacts
+# Publish build artifacts to Azure Pipelines/TFS or a file share
+- task: PublishBuildArtifacts@1
+  inputs:
+    pathtoPublish: '$(Build.ArtifactStagingDirectory)' 
+
+- task: DownloadBuildArtifacts@0
+  displayName: 'Download Build Artifacts'
+  inputs:
+    artifactName: drop
+
+- task: ShellScript@2
+  displayName: 'Run unit tests'
+  inputs:
+    scriptPath: ./localRunTests.sh
+    args: ${{ parameters.stackName }} $(Build.ArtifactStagingDirectory)

--- a/Kudulite-HotPatch/CI/generateDockerfilesforKuduliteHotPatchImageJob.yaml
+++ b/Kudulite-HotPatch/CI/generateDockerfilesforKuduliteHotPatchImageJob.yaml
@@ -1,0 +1,26 @@
+parameters:
+  ascName: WAWS_Container_Images
+  acrName: wawsimages.azurecr.io
+  baseImageName: "mcr.microsoft.com/appsvc"
+  baseImageVersion: "20220414.2"
+  kuduliteInternalRepo: $(KUDU_REPO)
+  kuduliteBranch: $(KUDULITE_BRANCH)
+  
+steps:
+- script: |
+    if [ "$(InitialChecks)" != "true" ]
+    then
+      echo "Invalid configuration."
+      echo "Variable 'InitialChecks' needs to be 'true' to run this build."
+      exit 1
+    fi
+  displayName: 'Validate pipeline run'
+
+- task: ComponentGovernanceComponentDetection@0
+
+- task: ShellScript@2
+  displayName: 'Generate KuduLite Docker Files'
+  inputs:
+    scriptPath: ./Kudulite-HotPatch/Scripts/generateDockerfilesforKuduliteHotPatchImage.sh
+    args: $(Build.ArtifactStagingDirectory) ${{ parameters.baseImageName }} ${{ parameters.baseImageVersion }} ${{ parameters.kuduliteInternalRepo }} $(System.DefaultWorkingDirectory)/Config ${{ parameters.kuduliteBranch }}
+

--- a/Kudulite-HotPatch/LocalDevelopment/localBuildKuduliteHotPatchImages.sh
+++ b/Kudulite-HotPatch/LocalDevelopment/localBuildKuduliteHotPatchImages.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Usage : Build and tag docker image for Kudulite hotfix locally
+# 
+
+BuildNumber=$1
+DockerFileDir=`pwd`"/output/DockerFiles"
+shift
+if [ -z "$BuildNumber" ]
+then
+    echo "please supply a build number"
+    exit
+fi
+
+
+function buildAndTagImages()
+{
+    local stackName=$1
+
+    local githubRepo=$2 ;
+    githubRepo="${githubRepo:="GitRepo"}" 
+
+    local buildNumber=$3  
+    buildNumber="${buildNumber:="$BuildNumber"}" 
+    Kudulite-Hotfix/Scripts/buildKuduliteHotfixImage.sh $DockerFileDir appsvctest "Config" $BuildNumber "kudulite" "PullRequest" $githubRepo $buildNumber $stackVersion
+}
+
+buildAndTagImages "kudulite"
+buildAndTagImages "kudulite" "GitRepo-DynInst" buster_$BuildNumber

--- a/Kudulite-HotPatch/LocalDevelopment/localGenerateDockerFilesForKuduliteHotPatchImage.sh
+++ b/Kudulite-HotPatch/LocalDevelopment/localGenerateDockerFilesForKuduliteHotPatchImage.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# Usage : Generate docker file Kudulite HotPatch image
+#   
+# Example :
+# $0 
+# 
+
+while getopts ":b:k:" opt; do
+  case $opt in
+    b) kuduliteBaseImageTag="$OPTARG"    
+    ;;
+    k) kuduliteBranch="$OPTARG"
+    ;;
+    \?) echo "Invalid option -$OPTARG" >&2
+        exit 1
+    ;;
+  esac
+done
+
+
+artifactStagingDirectory="output/DockerFiles"
+baseImageName="${oryxBaseImageName:="mcr.microsoft.com/appsvc"}" 
+baseImageVersion="${kuduliteBaseImageTag:="20220330.1"}" # Kudulite image which is taken in current ANT release
+appSvcGitUrl="https://github.com/Azure-App-Service"
+kuduliteBranch="${kuduliteBranch:="dev"}"
+configDir="Config"
+
+echo "Base Kudulite Image : $baseImageName/$baseImageVersion"
+echo "Kudulite branch     : $kuduliteBranch"
+
+echo ""
+rm -rf $artifactStagingDirectory
+
+function generateDockerFilesFor_KuduliteHotPatch()
+{
+    chmod u+x Kudulite-HotPatch/Scripts/generateDockerfilesforKuduliteHotPatchImage.sh
+    local kuduliteRepoUrl="https://msazure.visualstudio.com/DefaultCollection/Antares/_git/AAPT-Antares-KuduLite"
+    Kudulite-HotPatch/Scripts/generateDockerfilesforKuduliteHotPatchImage.sh $artifactStagingDirectory $baseImageName $baseImageVersion $kuduliteRepoUrl $configDir $kuduliteBranch
+}
+
+generateDockerFilesFor_KuduliteHotPatch

--- a/Kudulite-HotPatch/Scripts/buildKuduliteHotPatchImage.sh
+++ b/Kudulite-HotPatch/Scripts/buildKuduliteHotPatchImage.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT license.
+# This script builds Docker Images for all stacks on Azure App Service on Linux.
+# --------------------------------------------------------------------------------------------
+
+set -e
+
+
+# Directory for Generated Docker Files
+declare -r SYSTEM_ARTIFACTS_DIR="$1"
+declare -r APP_SVC_BRANCH_PREFIX="$2"           # appsvc, appsvctest
+declare -r CONFIG_DIR="$3"
+declare -r PIPELINE_BUILD_NUMBER="$4"
+declare -r STACK="$5"
+declare -r BUILD_REASON="$6"
+declare -r FILES_ROOT_PATH="$7"
+declare -r IMG_TAG="$8"
+declare -r WAWS_IMAGE_REPO_NAME="wawsimages.azurecr.io"
+declare -r ACR_BUILD_IMAGES_ARTIFACTS_FILE="$SYSTEM_ARTIFACTS_DIR/builtImages.txt"
+
+function displayArtifactsDir()
+{
+    local artifactsDir=$1
+    echo "Listing artifacts dir :"
+    echo "--------------------------"
+    ls $artifactsDir
+    echo 
+}
+
+function displayInformationRegardingImageToBeBuilt()
+{
+    local tag=$1
+    local dockerFilePath=$2
+    echo "Building test image with "
+    echo "--------------------------"
+    echo "Tag           : $BuildVerRepoTag "
+    echo "DockerFile    : $appSvcDockerfilePath"
+    echo
+}
+
+function buildDockerImage() 
+{    
+    # KuduLite Image, add single image support
+
+    local BuildVerRepoTagUpperCase="${WAWS_IMAGE_REPO_NAME}/${STACK}:${IMG_TAG}"
+    local BuildVerRepoTag="${BuildVerRepoTagUpperCase,,}"
+    local MCRRepoTagUpperCase="${WAWS_IMAGE_REPO_NAME}/public/appsvc/${STACK}:${IMG_TAG}"
+    local MCRRepoTag="${MCRRepoTagUpperCase,,}"
+    local appSvcDockerfilePath="${SYSTEM_ARTIFACTS_DIR}/${STACK}/${FILES_ROOT_PATH}/Dockerfile"
+
+    displayArtifactsDir "${SYSTEM_ARTIFACTS_DIR}"
+    cd "${SYSTEM_ARTIFACTS_DIR}/${STACK}/${FILES_ROOT_PATH}"
+    displayInformationRegardingImageToBeBuilt $BuildVerRepoTag $appSvcDockerfilePath
+    echo docker build -t "$BuildVerRepoTag" -f "$appSvcDockerfilePath" .
+    docker build -t "$BuildVerRepoTag" -f "$appSvcDockerfilePath" .
+    docker tag $BuildVerRepoTag $MCRRepoTag
+
+    # only push the images if merging to the master
+    if [ "$BUILD_REASON" != "PullRequest" ]; then
+        docker push $BuildVerRepoTag
+        docker push $MCRRepoTag
+    fi
+
+    echo $MCRRepoTag >> $SYSTEM_ARTIFACTS_DIR/${STACK}builtImageList
+
+}
+
+buildDockerImage

--- a/Kudulite-HotPatch/Scripts/generateDockerfilesforKuduliteHotPatchImage.sh
+++ b/Kudulite-HotPatch/Scripts/generateDockerfilesforKuduliteHotPatchImage.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+
+# This script generates Dockerfiles for Kudulite Hotfix Images for Azure App Service on Linux.
+#
+# --------------------------------
+# What are Kudulite HotPatch Images?
+# --------------------------------
+# Generally we use oryx/build as the base image to build Kudulite images. During a release, 
+# oryx/build image remains constant. We only keep updating Kudulite code to take in any fixes.
+# To keep the number of unique layers smaller, we use take a HotPatch approach and generate Kudulite Hotfix Images
+# We use previous Kudulite image as base image and just build the Kudulite code
+
+set -e
+
+# Current Working Dir
+declare -r ORIG_DIR=`pwd`
+declare -r DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+# Directory for Generated Docker Files
+declare -r STACK_NAME="KuduLite"
+declare -r SYSTEM_ARTIFACTS_DIR="$1"
+declare -r BASE_IMAGE_REPO_NAME="$2/kudulite"
+declare -r BASE_IMAGE_VERSION_STREAM_FEED="$3"                     # Base Image Version; Kudulite tag : 20190819.2
+declare -r APPSVC_KUDULITE_REPO="$4"        
+declare -r CONFIG_DIR="$5"                                         # ${Current_Repo}/Config
+declare -r METADATA_FILE="$SYSTEM_ARTIFACTS_DIR/metadata"
+declare -r APP_SVC_REPO_DIR="$SYSTEM_ARTIFACTS_DIR/$STACK_NAME/GitRepo"
+declare -r KUDULITE_BRANCH=$6
+declare -r APP_SVC_REPO_BRANCH="${KUDULITE_BRANCH:="dev"}"
+declare -r DYN_INST_REPO_DIR="$SYSTEM_ARTIFACTS_DIR/$STACK_NAME/GitRepo-DynInst"
+declare -r DYN_INST_REPO_BRANCH="${KUDULITE_BRANCH:="dev"}"
+
+
+function generateDockerFilesForKuduliteHotfixImage()
+{
+
+    local is_buster_image=$1
+    is_buster_image="${is_buster_image:=false}" 
+
+    local dockerfile_name="Dockerfile-RP-Main"
+    local kudulite_tag=$BASE_IMAGE_VERSION_STREAM_FEED
+    local current_version_directory="${APP_SVC_REPO_DIR}/"
+
+    if [ "$is_buster_image" = "true" ]; then
+        dockerfile_name="Dockerfile-RP-Buster"
+        kudulite_tag="buster_$BASE_IMAGE_VERSION_STREAM_FEED"
+        current_version_directory="$DYN_INST_REPO_DIR"
+    fi
+
+    # Example line:
+    # use base image as Kudulite - mcr.microsoft.com/appsvc/kudulite:$BASE_IMAGE_VERSION_STREAM_FEED
+
+    # Base Image
+    local base_image_name="${BASE_IMAGE_REPO_NAME}:hotfix_$kudulite_tag"
+    
+    local target_dockerfile="${current_version_directory}/RolePatcher/$dockerfile_name"
+    
+    #Rename Dockerfile for kudu
+    mv ${target_dockerfile} ${current_version_directory}/Dockerfile
+
+    echo "Generating Dockerfile for hotfix kudulite image '$base_image_name' in directory '$current_version_directory'..."
+
+    # Replace placeholders, changing sed delimeter since '/' is used in path
+    sed -i "s|BASE_IMAGE|$base_image_name|g" "${current_version_directory}/Dockerfile"
+
+    # Register the generated docker files with metadata dir
+    echo "${APP_SVC_REPO_DIR}, " > $METADATA_FILE
+
+    echo "Done."
+
+}
+
+function pullAppSvcRepo()
+{
+    # Create Stretch based Kudulite Hotfix Image 
+    echo "Cloning App Service KuduLiteBuild Repository in $APP_SVC_REPO_DIR"
+    git clone $APPSVC_KUDULITE_REPO $APP_SVC_REPO_DIR
+    cd $APP_SVC_REPO_DIR
+    echo "Checking out branch $APP_SVC_REPO_BRANCH"
+    git checkout $APP_SVC_REPO_BRANCH
+    cd $ORIG_DIR
+    chmod -R 777 $APP_SVC_REPO_DIR
+    echo
+
+    # Create Buster based Kudulite Hotfix Image 
+    echo "Cloning App Service KuduLiteBuild Repository in $DYN_INST_REPO_DIR"
+    git clone $APPSVC_KUDULITE_REPO $DYN_INST_REPO_DIR
+    cd $DYN_INST_REPO_DIR
+    echo "Checking out branch $DYN_INST_REPO_BRANCH"
+    git checkout $DYN_INST_REPO_BRANCH
+    cd $ORIG_DIR
+    chmod -R 777 $DYN_INST_REPO_DIR
+}
+
+pullAppSvcRepo
+
+# Arg 1 : Is Buster Image
+generateDockerFilesForKuduliteHotfixImage false
+echo
+generateDockerFilesForKuduliteHotfixImage true


### PR DESCRIPTION
Generally we use oryx/build as the base image to build Kudulite images. During a release, 
oryx/build image remains constant. We only keep updating Kudulite code to take in any fixes.
To keep the number of unique layers smaller, we use take a HotPatch approach and generate Kudulite HotPatch Images
We use previous Kudulite image as base image and just build the Kudulite code