### PR TITLE
Excluding specific folders from PR builds

### DIFF
--- a/CI.yml
+++ b/CI.yml
@@ -289,3 +289,9 @@ jobs:
       echo "##vso[task.setvariable variable=PushBuildImages;]false"
       echo "##vso[task.setvariable variable=PushRuntimeImages;]false"
 trigger: none
+
+pr:
+  paths:
+    exclude: 
+      - "Kudulite-HotPatch/*"
+      - "V2/*"

--- a/CI.yml
+++ b/CI.yml
@@ -294,4 +294,4 @@ pr:
   paths:
     exclude: 
       - "Kudulite-HotPatch/*"
-      - "V2/*"
+      - "v2/*"

--- a/Kudulite-HotPatch/CI/Kudulite-HotPatch.yaml
+++ b/Kudulite-HotPatch/CI/Kudulite-HotPatch.yaml
@@ -53,3 +53,5 @@ pr:
   paths:
     include: 
       - "../*"
+    exclude:
+      - "../LocalDevelopment/*"

--- a/Kudulite-HotPatch/CI/Kudulite-HotPatch.yaml
+++ b/Kudulite-HotPatch/CI/Kudulite-HotPatch.yaml
@@ -48,3 +48,8 @@ jobs:
       stackName: KuduLite
 
 trigger: none
+
+pr:
+  paths:
+    include: 
+      - "../*"


### PR DESCRIPTION
Currently we have two pipelines, ImageBuilder CI and Kudulite HotPatch. Every small change we make, the pipeline runs and pushes images for all stacks to MCR

To avoid this,
- Excluding specific folders such as Kudulite-HotPatch/* and v2/* from PR builds as they have separate pipelines for this.
- Similarly, PR builds for Kudulite-HotPatch pipeline run only changes are made to Kudulite-HotPatch/* folder