### PR TITLE
Separating Build and Publish images stages

### DIFF
--- a/v2/local_development/local_build_docker_images.sh
+++ b/v2/local_development/local_build_docker_images.sh
@@ -62,7 +62,7 @@ function build_and_tag_runtime_image()
   local config_directory="$IMAGEBUILDER_REPO_V2_SRC_FOLDER/$stack_name"
   
   echo "Using local config directory as $config_directory"
-  $IMAGEBUILDER_REPO_V2_SRC_FOLDER/build_and_push_runtime_images.sh $GENERATED_DOCKERFILES_DIRECTORY appsvctest $config_directory $BUILD_TAG "$stack_name" "PullRequest" "$STACK_VERSION"
+  $IMAGEBUILDER_REPO_V2_SRC_FOLDER/build_runtime_images.sh $GENERATED_DOCKERFILES_DIRECTORY appsvctest $config_directory $BUILD_TAG "$stack_name" "PullRequest" "$STACK_VERSION"
 }
 
 # Summary : 

--- a/v2/pipelines/runtime_images/build_runtime_image_job.yaml
+++ b/v2/pipelines/runtime_images/build_runtime_image_job.yaml
@@ -32,5 +32,5 @@ steps:
 - task: ShellScript@2
   displayName: 'Building Image'
   inputs:
-    scriptPath: $(System.DefaultWorkingDirectory)/v2/src/build_and_push_runtime_images.sh
+    scriptPath: $(System.DefaultWorkingDirectory)/v2/src/build_runtime_images.sh
     args: $(Build.ArtifactStagingDirectory) appsvctest "$(System.DefaultWorkingDirectory)/v2/src/${{ parameters.stackName }}" $(Build.BuildNumber) ${{ parameters.stackName }} $(Build.Reason) ${{ parameters.stackVersion }}

--- a/v2/pipelines/runtime_images/python_CI.yaml
+++ b/v2/pipelines/runtime_images/python_CI.yaml
@@ -139,4 +139,23 @@ jobs:
           stackName : ${{ variables.stackName }}
           stackVersion : 3.10
 
+- job: Job_Push_Python_Images_To_MCR
+    displayName: Push images to MCR
+    dependsOn: 
+      Job_Build_Python_27_Image
+      Job_Build_Python_36_Image
+      Job_Build_Python_37_Image
+      Job_Build_Python_38_Image
+      Job_Build_Python_39_Image
+      Job_Build_Python_310_Image
+    pool:
+      vmImage: ubuntu-18.04
+    timeoutInMinutes: 15
+    steps:
+      - task: ShellScript@2
+        displayName: 'Publish python images to MCR'
+        inputs:
+          scriptPath: $(System.DefaultWorkingDirectory)/v2/src/push_images_to_mcr.sh
+          args: "$(Build.ArtifactStagingDirectory)" "${{ parameters.stackName }}" $(Build.BuildNumber)
+
 trigger: none

--- a/v2/src/kudulite/build_and_push_kudulite_images.sh
+++ b/v2/src/kudulite/build_and_push_kudulite_images.sh
@@ -13,6 +13,15 @@ declare -r KUDULITE_TYPE_TO_BUILD=$5            # debian flavour of Kudu ( stret
 declare -r STACK="kudulite"
 declare -r WAWS_IMAGE_REPO_NAME="wawsimages.azurecr.io"
 
+# Summary :
+# This function helps in clearing the file that contains the list of images that must be pushed to MCR
+#
+# Arguments :
+function clean_list_of_images_to_push_to_mcr()
+{
+    rm -f $SYSTEM_ARTIFACTS_DIR/$LIST_OF_IMAGES_TO_PUSH_TO_MCR
+}
+
 # Summary : 
 # This function helps in building the kudulite image
 #
@@ -45,12 +54,12 @@ function build_kudulite_image()
     docker build -t "$wawsimages_acr_tag_name_in_lower_case" -f "$kudulite_image_docker_file_path" .
     docker tag $wawsimages_acr_tag_name_in_lower_case $mcr_tag_in_lower_case
 
-    # only push the images if merging to the master
-    if [ "$BUILD_REASON" != "PullRequest" ]; then
-        docker push $wawsimages_acr_tag_name_in_lower_case
-        docker push $mcr_tag_in_lower_case
-    fi
+    # Adding image names to a file which contains list of images that must be pushed to MCR
+    echo $wawsimages_acr_tag_name_in_lower_case >> $SYSTEM_ARTIFACTS_DIR/$LIST_OF_IMAGES_TO_PUSH_TO_MCR
+    echo $mcr_tag_in_lower_case >> $SYSTEM_ARTIFACTS_DIR/$LIST_OF_IMAGES_TO_PUSH_TO_MCR    
 }
+
+clean_list_of_images_to_push_to_mcr
 
 # if KUDULITE_TYPE_TO_BUILD is empty (not specified), build all types
 if [[ -z $KUDULITE_TYPE_TO_BUILD ]]; then

--- a/v2/src/kudulite/generate_dockerfiles_for_kudulite_images.sh
+++ b/v2/src/kudulite/generate_dockerfiles_for_kudulite_images.sh
@@ -18,7 +18,12 @@ declare -r BASE_IMAGE_REPO_NAME="$5/build"                              # mcr.mi
 declare -r ORYX_TAG="$6"                                                # Base Image Version; Oryx Version : 20190819.2
 
 declare -r APPSVC_REPO_DIR="$SYSTEM_ARTIFACTS_DIR/kudulite/GitRepo"
-declare -r METADATA_FILE="$SYSTEM_ARTIFACTS_DIR/metadata"               # file which contains list of images that are built 
+declare -r METADATA_FILE="$SYSTEM_ARTIFACTS_DIR/metadata"               # has value of APPSVC_REPO_DIR. This file will be removed soon.
+
+# In Image Builder v1, we were building and pushing images to MCR and in the later steps were testing the image
+# In v2 version, we want to avoid this. So we build the images, run a script that can test images and 
+# if they pass use another script to push images to MCR.
+declare -r LIST_OF_IMAGES_TO_PUSH_TO_MCR="kudulite_LIST_OF_IMAGES_TO_PUSH_TO_MCR"
 
 # Summary :
 # Replaces BASE_IMAGE_NAME_PLACEHOLDER in Dockerfile with mcr.microsoft.com/oryx/build:<tag>

--- a/v2/src/push_images_to_mcr.sh
+++ b/v2/src/push_images_to_mcr.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# --------------------------------------------------------------------------------------------
+# This script pushes generated Docker Images to MCR
+# Note: the script to build images be run prior to executing this script
+# --------------------------------------------------------------------------------------------
+
+set -e
+
+declare -r SYSTEM_ARTIFACTS_DIR="$1"            # drop/ - when called from devops ; ../../output - when called from local
+declare -r STACK_NAME=$2
+declare -r BUILD_REASON=$3
+
+declare -r LIST_OF_IMAGES_TO_PUSH_TO_MCR="${STACK_NAME}_LIST_OF_IMAGES_TO_PUSH_TO_MCR"
+
+if [[ -z $STACK_NAME ]]; then
+    echo "ERROR: Please specify stack name"
+    exit
+fi
+
+if [[ -z $BUILD_REASON ]]; then
+    echo "ERROR: Build Reason must be specified"
+    exit
+fi
+
+while IFS= read -r image_name; do
+    echo "Attempting to push image $image_name to MCR"
+
+    # Push the generated images to MCR if the build reason is not pull request
+    if [ "$BUILD_REASON" != "PullRequest" ]; then
+        if [ ! -z $image_name ]; then
+            docker push $image_name               
+        fi
+    else
+        echo "ERROR: Unable to push images to MCR. (Build Reason : $BUILD_REASON)"
+    fi
+
+    echo
+
+done < $SYSTEM_ARTIFACTS_DIR/$LIST_OF_IMAGES_TO_PUSH_TO_MCR


### PR DESCRIPTION
In Image Builder v1, we were building and pushing images to MCR and in the later steps were testing the image

In v2 version, we want to avoid this. So, 
- we build the images, 
- run a script that can test images 
- if they pass use another script to push images to MCR.

The goal is to ensure that broken images should not be pushed to MCR.

Work Item: https://msazure.visualstudio.com/Antares/_workitems/edit/14405122