### PR TITLE
Removing Sensitive items from wordpress code

### DIFF
--- a/GenerateDockerFiles/wordpress/wordpress/wordpress_src/wordpress-azure/wp-admin/includes/class-ftp.php
+++ b/GenerateDockerFiles/wordpress/wordpress/wordpress_src/wordpress-azure/wp-admin/includes/class-ftp.php
@@ -144,7 +144,7 @@ class ftp_base {
 		$this->SetTimeout(30);
 		$this->Passive(!$this->_port_available);
 		$this->_login="anonymous";
-		$this->_password="anon@ftp.com";
+		$this->_password="";
 		$this->_features=array();
 	    $this->OS_local=FTP_OS_Unix;
 		$this->OS_remote=FTP_OS_Unix;
@@ -362,7 +362,7 @@ class ftp_base {
 		if(!is_null($user)) $this->_login=$user;
 		else $this->_login="anonymous";
 		if(!is_null($pass)) $this->_password=$pass;
-		else $this->_password="anon@anon.com";
+		else $this->_password="";
 		if(!$this->_exec("USER ".$this->_login, "login")) return FALSE;
 		if(!$this->_checkCode()) return FALSE;
 		if($this->_code!=230) {

--- a/GenerateDockerFiles/wordpress/wordpress/wordpress_src/wordpress-azure/wp-admin/includes/file.php
+++ b/GenerateDockerFiles/wordpress/wordpress/wordpress_src/wordpress-azure/wp-admin/includes/file.php
@@ -1443,7 +1443,7 @@ function wp_trusted_keys() {
 
 	if ( time() < 1617235200 ) {
 		// WordPress.org Key #1 - This key is only valid before April 1st, 2021.
-		$trusted_keys[] = 'fRPyrxb/MvVLbdsYi+OOEv4xc+Eqpsj+kkAS6gNOkI0=';
+		$trusted_keys[] = '';
 	}
 
 	// TODO: Add key #2 with longer expiration.

--- a/GenerateDockerFiles/wordpress/wordpress/wordpress_src/wordpress-azure/wp-content/plugins/w3-total-cache/Cdnfsd_TransparentCDN_Page_View.js
+++ b/GenerateDockerFiles/wordpress/wordpress/wordpress_src/wordpress-azure/wp-content/plugins/w3-total-cache/Cdnfsd_TransparentCDN_Page_View.js
@@ -15,7 +15,7 @@ jQuery( document ).ready( function( $ ) {
 				client_id = 'client_id' +
 					'=' +
 					document.getElementById( 'cdnfsd_transparentcdn_clientid' ).value,
-				client_secret = 'client_secret' +
+				client_secret = '' +
 					'=' +
 					document.getElementById( 'cdnfsd_transparentcdn_clientsecret' ).value,
 				grant_type = 'grant_type=client_credentials',

--- a/GenerateDockerFiles/wordpress/wordpress/wordpress_src/wordpress-azure/wp-content/plugins/w3-total-cache/lib/Azure/MicrosoftAzureStorage/Common/Internal/Resources.php
+++ b/GenerateDockerFiles/wordpress/wordpress/wordpress_src/wordpress-azure/wp-content/plugins/w3-total-cache/lib/Azure/MicrosoftAzureStorage/Common/Internal/Resources.php
@@ -193,7 +193,7 @@ class Resources
     const WRAP_ACCESS_TOKEN            = 'wrap_access_token';
     const WRAP_ACCESS_TOKEN_EXPIRES_IN = 'wrap_access_token_expires_in';
     const WRAP_NAME                    = 'wrap_name';
-    const WRAP_PASSWORD                = 'wrap_password';
+    const WRAP_PASSWORD                = '';
     const WRAP_SCOPE                   = 'wrap_scope';
 
     // HTTP Methods

--- a/GenerateDockerFiles/wordpress/wordpress/wordpress_src/wordpress-azure/wp-content/plugins/w3-total-cache/lib/Google/Auth/AssertionCredentials.php
+++ b/GenerateDockerFiles/wordpress/wordpress/wordpress_src/wordpress-azure/wp-content/plugins/w3-total-cache/lib/Google/Auth/AssertionCredentials.php
@@ -52,7 +52,7 @@ class W3TCG_Google_Auth_AssertionCredentials
       $serviceAccountName,
       $scopes,
       $privateKey,
-      $privateKeyPassword = 'notasecret',
+      $privateKeyPassword = '',
       $assertionType = 'http://oauth.net/grant_type/jwt/1.0/bearer',
       $sub = false,
       $useCache = true


### PR DESCRIPTION
ImageBuilder v2 is present in Azure DevOps. To migrate, we need to remove some sensitive items from code 