### PR TITLE
Increasing timeout for dotnetcore builds

### DIFF
--- a/CI.yml
+++ b/CI.yml
@@ -64,7 +64,7 @@ jobs:
   dependsOn: Job_GenerateDockerFiles
   pool:
     vmImage: ubuntu-18.04
-  timeoutInMinutes: 100
+  timeoutInMinutes: 140
   steps:
   - script: |
       echo "##vso[task.setvariable variable=InitialChecks;]true"


### PR DESCRIPTION
Image Builder pipeline was breaking as dotnetcore builds takes more than 100 minutes.
Increasing the timeout limit to 140 minutes.