### PR TITLE
Excluding cleanup job for ruby images

### DIFF
--- a/CleanUp/cleanDevACR.sh
+++ b/CleanUp/cleanDevACR.sh
@@ -27,7 +27,7 @@ declare -r azQuery="[?timestamp<=\`$tsLimit\`].digest"
 
 for repo in "${REPOS[@]}"
 do
-    if [[ "$repo" == *"staticappsclient"* ]]; then
+    if [[ "$repo" == *"staticappsclient"* || "$repo" == *"ruby"* ]]; then
         echo "Skipping staticappsclient image $repo"
         continue
     fi

--- a/CleanUp/cleanDevACR.sh
+++ b/CleanUp/cleanDevACR.sh
@@ -28,7 +28,7 @@ declare -r azQuery="[?timestamp<=\`$tsLimit\`].digest"
 for repo in "${REPOS[@]}"
 do
     if [[ "$repo" == *"staticappsclient"* || "$repo" == *"ruby"* ]]; then
-        echo "Skipping staticappsclient image $repo"
+        echo "Skipping $repo image"
         continue
     fi
 


### PR DESCRIPTION
Currently imagebuilder pipeline is broken with the error

WARNING: This command has been deprecated and will be removed in a future release. Use 'acr manifest list-metadata' instead.
Deleting 4 images created before '2022-04-30T07:25:12+00:00' in repository 'public/appsvc/ruby'...
WARNING: This operation will delete the manifest 'sha256:<digest>'
ERROR: Error: manifest sha256:<digest> is not found. Correlation ID: ef8b4a30-68a8-449f-8a1c-617229737a06.
##[error]Script failed with exit code: 1

To unblock the pipeline, I am excluding ruby images to get clean up job.
Will fix the issue in another pipeline.
