### PR TITLE
Updating base tag to 20220603.1

### DIFF
--- a/GenerateDockerFiles/dockerFilesGenerateTask.yml
+++ b/GenerateDockerFiles/dockerFilesGenerateTask.yml
@@ -2,7 +2,7 @@ parameters:
   ascName: WAWS_Container_Images
   acrName: wawsimages.azurecr.io
   baseImageName: "mcr.microsoft.com/oryx"
-  baseImageVersion: "20220519.2"
+  baseImageVersion: "20220603.1"
   appSvcGitUrl: "https://github.com/Azure-App-Service"
   kuduliteInternalRepo: $(KUDU_REPO)
   DiagnosticServerInternalRepo: $(DiagnosticServer_REPO)

--- a/localGenerateDockerFiles.sh
+++ b/localGenerateDockerFiles.sh
@@ -30,7 +30,7 @@ done
 
 artifactStagingDirectory="output/DockerFiles"
 baseImageName="${oryxBaseImageName:="mcr.microsoft.com/oryx"}" 
-baseImageVersion="${oryxTagName:="20220519.2"}" # change me as needed
+baseImageVersion="${oryxTagName:="20220603.1"}" # change me as needed
 appSvcGitUrl="https://github.com/Azure-App-Service"
 kuduliteBranch="${kuduliteBranch:="dev"}"
 configDir="Config"


### PR DESCRIPTION
Updating base tag to 20220603.1

The base image contains latest patch versions for node js and spotlight logs for golang and dotnetcore