### PR TITLE
Removing publish of artifacts during build

### DIFF
--- a/BuildAndTagImages/buildImageJob.yml
+++ b/BuildAndTagImages/buildImageJob.yml
@@ -41,17 +41,6 @@ steps:
     scriptPath: ./BuildAndTagImages/build.sh
     args: $(Build.ArtifactStagingDirectory)/drop appsvctest $(System.DefaultWorkingDirectory)/Config $(Build.BuildNumber) ${{ parameters.stackName }} $(Build.Reason) ${{ parameters.filesRootPath }} ${{ parameters.imgTag }} ${{ parameters.stackVersion }}
 
-# Publish Build Artifacts
-# Publish build artifacts to Azure Pipelines/TFS or a file share
-- task: PublishBuildArtifacts@1
-  inputs:
-    pathtoPublish: '$(Build.ArtifactStagingDirectory)' 
-
-- task: DownloadBuildArtifacts@0
-  displayName: 'Download Build Artifacts'
-  inputs:
-    artifactName: drop
-
 - task: ShellScript@2
   displayName: 'Run unit tests'
   inputs:

--- a/BuildAndTagImages/buildImageJob.yml
+++ b/BuildAndTagImages/buildImageJob.yml
@@ -45,4 +45,4 @@ steps:
   displayName: 'Run unit tests'
   inputs:
     scriptPath: ./localRunTests.sh
-    args: ${{ parameters.stackName }} $(Build.ArtifactStagingDirectory)
+    args: ${{ parameters.stackName }} $(Build.ArtifactStagingDirectory)/drop

--- a/Tests/KuduLite/Tests.csproj
+++ b/Tests/KuduLite/Tests.csproj
@@ -29,7 +29,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Content Include="/home/vsts/work/1/a/drop/drop/*builtImageList">
+    <Content Include="/home/vsts/work/1/a/drop/*builtImageList">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>

--- a/Tests/dotnetcore/Tests.csproj
+++ b/Tests/dotnetcore/Tests.csproj
@@ -21,7 +21,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Content Include="/home/vsts/work/1/a/drop/drop/*builtImageList">
+    <Content Include="/home/vsts/work/1/a/drop/*builtImageList">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>

--- a/Tests/node/Tests.csproj
+++ b/Tests/node/Tests.csproj
@@ -21,7 +21,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Content Include="/home/vsts/work/1/a/drop/drop/*builtImageList">
+    <Content Include="/home/vsts/work/1/a/drop/*builtImageList">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>

--- a/Tests/php/Tests.csproj
+++ b/Tests/php/Tests.csproj
@@ -21,7 +21,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Content Include="/home/vsts/work/1/a/drop/drop/*builtImageList">
+    <Content Include="/home/vsts/work/1/a/drop/*builtImageList">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>

--- a/Tests/python/Tests.csproj
+++ b/Tests/python/Tests.csproj
@@ -21,7 +21,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Content Include="/home/vsts/work/1/a/drop/drop/*builtImageList">
+    <Content Include="/home/vsts/work/1/a/drop/*builtImageList">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>

--- a/localRunTests.sh
+++ b/localRunTests.sh
@@ -7,9 +7,9 @@ if [ ! -z "$artifacts" ]
 then
     echo "Specified artificats directory is $artifacts"
     ls -R $artifacts
-    echo "$artifacts/*builtImageList"
-    echo "/home/vsts/work/1/s/Tests/$stack"
+    echo "Copying $artifacts/*builtImageList to /home/vsts/work/1/s/Tests/$stack"
     cp -R $artifacts/*builtImageList /home/vsts/work/1/s/Tests/$stack
+    ls -R /home/vsts/work/1/s/Tests/$stack
 fi
 
 

--- a/localRunTests.sh
+++ b/localRunTests.sh
@@ -5,6 +5,8 @@ stack="$1"
 artifacts="$2"
 if [ ! -z "$artifacts" ]
 then
+    echo "Specified artificats directory is $artifacts"
+    ls -R $artifacts
     echo "$artifacts/*builtImageList"
     echo "/home/vsts/work/1/s/Tests/$stack"
     cp -R $artifacts/*builtImageList /home/vsts/work/1/s/Tests/$stack

--- a/localRunTests.sh
+++ b/localRunTests.sh
@@ -5,9 +5,9 @@ stack="$1"
 artifacts="$2"
 if [ ! -z "$artifacts" ]
 then
-    echo "$artifacts/drop/*builtImageList"
+    echo "$artifacts/*builtImageList"
     echo "/home/vsts/work/1/s/Tests/$stack"
-    cp -R $artifacts/drop/*builtImageList /home/vsts/work/1/s/Tests/$stack
+    cp -R $artifacts/*builtImageList /home/vsts/work/1/s/Tests/$stack
 fi
 
 

--- a/localRunTests.sh
+++ b/localRunTests.sh
@@ -1,15 +1,26 @@
 #!/bin/bash
 
 stack="$1"
-
 artifacts="$2"
+isTestRunLocally=$3
+
 if [ ! -z "$artifacts" ]
 then
-    echo "Specified artificats directory is $artifacts"
-    ls -R $artifacts
-    echo "Copying $artifacts/*builtImageList to /home/vsts/work/1/s/Tests/$stack"
-    cp -R $artifacts/*builtImageList /home/vsts/work/1/s/Tests/$stack
-    ls -R /home/vsts/work/1/s/Tests/$stack
+    echo "Artificats directory : $artifacts"
+    ls $artifacts
+    echo 
+
+    testsDir="/home/vsts/work/1/s/Tests/$stack"
+
+    if [[ ! -z "$isTestRunLocally" && "$isTestRunLocally" == "true" ]]; then
+        testsDir="Tests/$stack"
+    fi
+
+    echo "Copying $artifacts/*builtImageList to $testsDir"
+    cp -R $artifacts/*builtImageList $testsDir
+
+    echo "Tests Directory : $testsDir"
+    ls $testsDir
 fi
 
 


### PR DESCRIPTION
ImageBuilder pipeline jobs are timing out as the builds are taking long time.

One reason for this we publish artifacts and download for no reason.
![image](https://user-images.githubusercontent.com/84462339/172361802-a67be91b-4813-4a25-9829-49d7b2d0c134.png)

In this PR I am removing them