### PR TITLE
Gracefully handling exceptions during import of codeprofiler and appserviceapplogs

### DIFF
--- a/GenerateDockerFiles/python/template-3.10/gunicorn.conf.py
+++ b/GenerateDockerFiles/python/template-3.10/gunicorn.conf.py
@@ -1,17 +1,41 @@
-import appServiceAppLogs as asal
+app_service_app_logs_import_succeeded = False
+code_profiler_import_succeeded = False
 
-# appsvc_profiler is currenly installed from appsvc_code_profiler-1.0.0-py3-none-any.whl
-from appsvc_profiler import CodeProfilerInstaller
+try:
+    import appServiceAppLogs as asal
+    app_service_app_logs_import_succeeded = True
+    
+except Exception as e:
+    print(e)    
+
+try:
+    import os
+    
+    # appsvc_profiler is currenly installed from appsvc_code_profiler-1.0.0-py3-none-any.whl
+    from appsvc_profiler import CodeProfilerInstaller
+    from appsvc_profiler.constants import CodeProfilerConstants
+    from appsvc_profiler.helpers import is_like_true
+    code_profiler_import_succeeded = True
+    
+except Exception as e:
+    print(e)
 
 def post_worker_init(worker):
-    asal.startHandlerRegisterer()
+    if app_service_app_logs_import_succeeded:
+        asal.startHandlerRegisterer()
     
     try:
-        cpi = CodeProfilerInstaller()
-        cpi.install()              
+        c = CodeProfilerConstants()        
+        is_code_profiler_enabled_app_setting_value = os.environ.get(c.APP_SETTING_TO_ENABLE_CODE_PROFILER, None)
+        is_code_profiler_enabled = is_code_profiler_enabled_app_setting_value is None or is_like_true(is_code_profiler_enabled_app_setting_value)
+        
+        if code_profiler_import_succeeded and is_code_profiler_enabled:
+            cpi = CodeProfilerInstaller()
+            cpi.install()
             
     except Exception as e:
         print(e)
 
 def on_starting(server):
-    asal.initAppLogs()
+    if app_service_app_logs_import_succeeded:
+        asal.initAppLogs()

--- a/GenerateDockerFiles/python/template-3.10/gunicorn.conf.py
+++ b/GenerateDockerFiles/python/template-3.10/gunicorn.conf.py
@@ -4,35 +4,36 @@ code_profiler_import_succeeded = False
 try:
     import appServiceAppLogs as asal
     app_service_app_logs_import_succeeded = True
-    
+
 except Exception as e:
-    print(e)    
+    print(e)
 
 try:
     import os
-    
-    # appsvc_profiler is currenly installed from appsvc_code_profiler-1.0.0-py3-none-any.whl
-    from appsvc_profiler import CodeProfilerInstaller
-    from appsvc_profiler.constants import CodeProfilerConstants
-    from appsvc_profiler.helpers import is_like_true
-    code_profiler_import_succeeded = True
-    
+    c = CodeProfilerConstants()
+    is_code_profiler_enabled_app_setting_value = os.environ.get(c.APP_SETTING_TO_ENABLE_CODE_PROFILER, None)
+    is_code_profiler_enabled = is_code_profiler_enabled_app_setting_value is None or is_like_true(is_code_profiler_enabled_app_setting_value)
+
+    if is_code_profiler_enabled:
+        # appsvc_profiler is currenly installed from appsvc_code_profiler-1.0.0-py3-none-any.whl
+        from appsvc_profiler import CodeProfilerInstaller
+        from appsvc_profiler.constants import CodeProfilerConstants
+        from appsvc_profiler.helpers import is_like_true
+        code_profiler_import_succeeded = True
+
 except Exception as e:
     print(e)
 
 def post_worker_init(worker):
     if app_service_app_logs_import_succeeded:
         asal.startHandlerRegisterer()
-    
+
     try:
-        c = CodeProfilerConstants()        
-        is_code_profiler_enabled_app_setting_value = os.environ.get(c.APP_SETTING_TO_ENABLE_CODE_PROFILER, None)
-        is_code_profiler_enabled = is_code_profiler_enabled_app_setting_value is None or is_like_true(is_code_profiler_enabled_app_setting_value)
-        
-        if code_profiler_import_succeeded and is_code_profiler_enabled:
+
+        if is_code_profiler_enabled and code_profiler_import_succeeded:
             cpi = CodeProfilerInstaller()
             cpi.install()
-            
+
     except Exception as e:
         print(e)
 

--- a/GenerateDockerFiles/python/template-3.7/gunicorn.conf.py
+++ b/GenerateDockerFiles/python/template-3.7/gunicorn.conf.py
@@ -1,17 +1,41 @@
-import appServiceAppLogs as asal
+app_service_app_logs_import_succeeded = False
+code_profiler_import_succeeded = False
 
-# appsvc_profiler is currenly installed from appsvc_code_profiler-1.0.0-py3-none-any.whl
-from appsvc_profiler import CodeProfilerInstaller
+try:
+    import appServiceAppLogs as asal
+    app_service_app_logs_import_succeeded = True
+    
+except Exception as e:
+    print(e)    
+
+try:
+    import os
+    
+    # appsvc_profiler is currenly installed from appsvc_code_profiler-1.0.0-py3-none-any.whl
+    from appsvc_profiler import CodeProfilerInstaller
+    from appsvc_profiler.constants import CodeProfilerConstants
+    from appsvc_profiler.helpers import is_like_true
+    code_profiler_import_succeeded = True
+    
+except Exception as e:
+    print(e)
 
 def post_worker_init(worker):
-    asal.startHandlerRegisterer()
+    if app_service_app_logs_import_succeeded:
+        asal.startHandlerRegisterer()
     
     try:
-        cpi = CodeProfilerInstaller()
-        cpi.install()              
+        c = CodeProfilerConstants()        
+        is_code_profiler_enabled_app_setting_value = os.environ.get(c.APP_SETTING_TO_ENABLE_CODE_PROFILER, None)
+        is_code_profiler_enabled = is_code_profiler_enabled_app_setting_value is None or is_like_true(is_code_profiler_enabled_app_setting_value)
+        
+        if code_profiler_import_succeeded and is_code_profiler_enabled:
+            cpi = CodeProfilerInstaller()
+            cpi.install()
             
     except Exception as e:
         print(e)
 
 def on_starting(server):
-    asal.initAppLogs()
+    if app_service_app_logs_import_succeeded:
+        asal.initAppLogs()

--- a/GenerateDockerFiles/python/template-3.7/gunicorn.conf.py
+++ b/GenerateDockerFiles/python/template-3.7/gunicorn.conf.py
@@ -4,35 +4,36 @@ code_profiler_import_succeeded = False
 try:
     import appServiceAppLogs as asal
     app_service_app_logs_import_succeeded = True
-    
+
 except Exception as e:
-    print(e)    
+    print(e)
 
 try:
     import os
-    
-    # appsvc_profiler is currenly installed from appsvc_code_profiler-1.0.0-py3-none-any.whl
-    from appsvc_profiler import CodeProfilerInstaller
-    from appsvc_profiler.constants import CodeProfilerConstants
-    from appsvc_profiler.helpers import is_like_true
-    code_profiler_import_succeeded = True
-    
+    c = CodeProfilerConstants()
+    is_code_profiler_enabled_app_setting_value = os.environ.get(c.APP_SETTING_TO_ENABLE_CODE_PROFILER, None)
+    is_code_profiler_enabled = is_code_profiler_enabled_app_setting_value is None or is_like_true(is_code_profiler_enabled_app_setting_value)
+
+    if is_code_profiler_enabled:
+        # appsvc_profiler is currenly installed from appsvc_code_profiler-1.0.0-py3-none-any.whl
+        from appsvc_profiler import CodeProfilerInstaller
+        from appsvc_profiler.constants import CodeProfilerConstants
+        from appsvc_profiler.helpers import is_like_true
+        code_profiler_import_succeeded = True
+
 except Exception as e:
     print(e)
 
 def post_worker_init(worker):
     if app_service_app_logs_import_succeeded:
         asal.startHandlerRegisterer()
-    
+
     try:
-        c = CodeProfilerConstants()        
-        is_code_profiler_enabled_app_setting_value = os.environ.get(c.APP_SETTING_TO_ENABLE_CODE_PROFILER, None)
-        is_code_profiler_enabled = is_code_profiler_enabled_app_setting_value is None or is_like_true(is_code_profiler_enabled_app_setting_value)
-        
-        if code_profiler_import_succeeded and is_code_profiler_enabled:
+
+        if is_code_profiler_enabled and code_profiler_import_succeeded:
             cpi = CodeProfilerInstaller()
             cpi.install()
-            
+
     except Exception as e:
         print(e)
 

--- a/GenerateDockerFiles/python/template-3.8/gunicorn.conf.py
+++ b/GenerateDockerFiles/python/template-3.8/gunicorn.conf.py
@@ -1,17 +1,41 @@
-import appServiceAppLogs as asal
+app_service_app_logs_import_succeeded = False
+code_profiler_import_succeeded = False
 
-# appsvc_profiler is currenly installed from appsvc_code_profiler-1.0.0-py3-none-any.whl
-from appsvc_profiler import CodeProfilerInstaller
+try:
+    import appServiceAppLogs as asal
+    app_service_app_logs_import_succeeded = True
+    
+except Exception as e:
+    print(e)    
+
+try:
+    import os
+    
+    # appsvc_profiler is currenly installed from appsvc_code_profiler-1.0.0-py3-none-any.whl
+    from appsvc_profiler import CodeProfilerInstaller
+    from appsvc_profiler.constants import CodeProfilerConstants
+    from appsvc_profiler.helpers import is_like_true
+    code_profiler_import_succeeded = True
+    
+except Exception as e:
+    print(e)
 
 def post_worker_init(worker):
-    asal.startHandlerRegisterer()
+    if app_service_app_logs_import_succeeded:
+        asal.startHandlerRegisterer()
     
     try:
-        cpi = CodeProfilerInstaller()
-        cpi.install()              
+        c = CodeProfilerConstants()        
+        is_code_profiler_enabled_app_setting_value = os.environ.get(c.APP_SETTING_TO_ENABLE_CODE_PROFILER, None)
+        is_code_profiler_enabled = is_code_profiler_enabled_app_setting_value is None or is_like_true(is_code_profiler_enabled_app_setting_value)
+        
+        if code_profiler_import_succeeded and is_code_profiler_enabled:
+            cpi = CodeProfilerInstaller()
+            cpi.install()
             
     except Exception as e:
         print(e)
 
 def on_starting(server):
-    asal.initAppLogs()
+    if app_service_app_logs_import_succeeded:
+        asal.initAppLogs()

--- a/GenerateDockerFiles/python/template-3.8/gunicorn.conf.py
+++ b/GenerateDockerFiles/python/template-3.8/gunicorn.conf.py
@@ -4,35 +4,36 @@ code_profiler_import_succeeded = False
 try:
     import appServiceAppLogs as asal
     app_service_app_logs_import_succeeded = True
-    
+
 except Exception as e:
-    print(e)    
+    print(e)
 
 try:
     import os
-    
-    # appsvc_profiler is currenly installed from appsvc_code_profiler-1.0.0-py3-none-any.whl
-    from appsvc_profiler import CodeProfilerInstaller
-    from appsvc_profiler.constants import CodeProfilerConstants
-    from appsvc_profiler.helpers import is_like_true
-    code_profiler_import_succeeded = True
-    
+    c = CodeProfilerConstants()
+    is_code_profiler_enabled_app_setting_value = os.environ.get(c.APP_SETTING_TO_ENABLE_CODE_PROFILER, None)
+    is_code_profiler_enabled = is_code_profiler_enabled_app_setting_value is None or is_like_true(is_code_profiler_enabled_app_setting_value)
+
+    if is_code_profiler_enabled:
+        # appsvc_profiler is currenly installed from appsvc_code_profiler-1.0.0-py3-none-any.whl
+        from appsvc_profiler import CodeProfilerInstaller
+        from appsvc_profiler.constants import CodeProfilerConstants
+        from appsvc_profiler.helpers import is_like_true
+        code_profiler_import_succeeded = True
+
 except Exception as e:
     print(e)
 
 def post_worker_init(worker):
     if app_service_app_logs_import_succeeded:
         asal.startHandlerRegisterer()
-    
+
     try:
-        c = CodeProfilerConstants()        
-        is_code_profiler_enabled_app_setting_value = os.environ.get(c.APP_SETTING_TO_ENABLE_CODE_PROFILER, None)
-        is_code_profiler_enabled = is_code_profiler_enabled_app_setting_value is None or is_like_true(is_code_profiler_enabled_app_setting_value)
-        
-        if code_profiler_import_succeeded and is_code_profiler_enabled:
+
+        if is_code_profiler_enabled and code_profiler_import_succeeded:
             cpi = CodeProfilerInstaller()
             cpi.install()
-            
+
     except Exception as e:
         print(e)
 

--- a/GenerateDockerFiles/python/template-3.9/gunicorn.conf.py
+++ b/GenerateDockerFiles/python/template-3.9/gunicorn.conf.py
@@ -1,17 +1,41 @@
-import appServiceAppLogs as asal
+app_service_app_logs_import_succeeded = False
+code_profiler_import_succeeded = False
 
-# appsvc_profiler is currenly installed from appsvc_code_profiler-1.0.0-py3-none-any.whl
-from appsvc_profiler import CodeProfilerInstaller
+try:
+    import appServiceAppLogs as asal
+    app_service_app_logs_import_succeeded = True
+    
+except Exception as e:
+    print(e)    
+
+try:
+    import os
+    
+    # appsvc_profiler is currenly installed from appsvc_code_profiler-1.0.0-py3-none-any.whl
+    from appsvc_profiler import CodeProfilerInstaller
+    from appsvc_profiler.constants import CodeProfilerConstants
+    from appsvc_profiler.helpers import is_like_true
+    code_profiler_import_succeeded = True
+    
+except Exception as e:
+    print(e)
 
 def post_worker_init(worker):
-    asal.startHandlerRegisterer()
+    if app_service_app_logs_import_succeeded:
+        asal.startHandlerRegisterer()
     
     try:
-        cpi = CodeProfilerInstaller()
-        cpi.install()              
+        c = CodeProfilerConstants()        
+        is_code_profiler_enabled_app_setting_value = os.environ.get(c.APP_SETTING_TO_ENABLE_CODE_PROFILER, None)
+        is_code_profiler_enabled = is_code_profiler_enabled_app_setting_value is None or is_like_true(is_code_profiler_enabled_app_setting_value)
+        
+        if code_profiler_import_succeeded and is_code_profiler_enabled:
+            cpi = CodeProfilerInstaller()
+            cpi.install()
             
     except Exception as e:
         print(e)
 
 def on_starting(server):
-    asal.initAppLogs()
+    if app_service_app_logs_import_succeeded:
+        asal.initAppLogs()

--- a/GenerateDockerFiles/python/template-3.9/gunicorn.conf.py
+++ b/GenerateDockerFiles/python/template-3.9/gunicorn.conf.py
@@ -4,35 +4,36 @@ code_profiler_import_succeeded = False
 try:
     import appServiceAppLogs as asal
     app_service_app_logs_import_succeeded = True
-    
+
 except Exception as e:
-    print(e)    
+    print(e)
 
 try:
     import os
-    
-    # appsvc_profiler is currenly installed from appsvc_code_profiler-1.0.0-py3-none-any.whl
-    from appsvc_profiler import CodeProfilerInstaller
-    from appsvc_profiler.constants import CodeProfilerConstants
-    from appsvc_profiler.helpers import is_like_true
-    code_profiler_import_succeeded = True
-    
+    c = CodeProfilerConstants()
+    is_code_profiler_enabled_app_setting_value = os.environ.get(c.APP_SETTING_TO_ENABLE_CODE_PROFILER, None)
+    is_code_profiler_enabled = is_code_profiler_enabled_app_setting_value is None or is_like_true(is_code_profiler_enabled_app_setting_value)
+
+    if is_code_profiler_enabled:
+        # appsvc_profiler is currenly installed from appsvc_code_profiler-1.0.0-py3-none-any.whl
+        from appsvc_profiler import CodeProfilerInstaller
+        from appsvc_profiler.constants import CodeProfilerConstants
+        from appsvc_profiler.helpers import is_like_true
+        code_profiler_import_succeeded = True
+
 except Exception as e:
     print(e)
 
 def post_worker_init(worker):
     if app_service_app_logs_import_succeeded:
         asal.startHandlerRegisterer()
-    
+
     try:
-        c = CodeProfilerConstants()        
-        is_code_profiler_enabled_app_setting_value = os.environ.get(c.APP_SETTING_TO_ENABLE_CODE_PROFILER, None)
-        is_code_profiler_enabled = is_code_profiler_enabled_app_setting_value is None or is_like_true(is_code_profiler_enabled_app_setting_value)
-        
-        if code_profiler_import_succeeded and is_code_profiler_enabled:
+
+        if is_code_profiler_enabled and code_profiler_import_succeeded:
             cpi = CodeProfilerInstaller()
             cpi.install()
-            
+
     except Exception as e:
         print(e)
 


### PR DESCRIPTION
When we get exceptions during import of any packages needed for code-profiler, it causes apps to not startup.
To avoid this, we wrap import statements inside try..except block.