### PR TITLE
Tested & verified way to fix Keep-Alive: timeout=X header

### DIFF
--- a/GenerateDockerFiles/node/node-template/startup/default-static-site.js
+++ b/GenerateDockerFiles/node/node-template/startup/default-static-site.js
@@ -1,7 +1,11 @@
 var express = require('express');
-var server = express();
+var app = express();
 var options = {
     index: ['index.html','hostingstart.html']
 };
-server.use('/', express.static('/opt/startup', options));
-server.listen(process.env.PORT);
+app.use('/', express.static('/opt/startup', options));
+var server = app.listen(process.env.PORT);
+// Must be longer than local proxy keep-alive timeout
+server.keepAliveTimeout = (65 * 1000);
+// Must be longer than server.keepAliveTimeout
+server.headersTimeout = (66 * 1000);

--- a/GenerateDockerFiles/node/pm2-template/startup/default-static-site.js
+++ b/GenerateDockerFiles/node/pm2-template/startup/default-static-site.js
@@ -1,7 +1,11 @@
 var express = require('express');
-var server = express();
+var app = express();
 var options = {
     index: ['index.html','hostingstart.html']
 };
-server.use('/', express.static('/opt/startup', options));
-server.listen(process.env.PORT);
+app.use('/', express.static('/opt/startup', options));
+var server = app.listen(process.env.PORT);
+// Must be longer than local proxy keep-alive timeout
+server.keepAliveTimeout = (65 * 1000);
+// Must be longer than server.keepAliveTimeout
+server.headersTimeout = (66 * 1000);


### PR DESCRIPTION
Verified way of setting `Keep-Alive: timeout=` header.
Thanks to Alejandro for running this one down.