### PR TITLE
Updating Oryx base image tag and removing EOL stretch images

### DIFF
--- a/Config/dotnetcoreVersionTemplateMap.txt
+++ b/Config/dotnetcoreVersionTemplateMap.txt
@@ -1,10 +1,5 @@
-1.0,1.0,debian-9,1.0
-1.1,1.1,debian-9,1.1
-2.0,2.0,debian-9,2.0
-2.1,2.1,debian-9,2.1
-2.2,2.2,debian-9,2.2
 3.0,3.0,debian-9,3.0
-3.1,3.1,debian-9,3.1|3.1-latest|lts
+3.1,3.1,debian-9,3.1|3.1-bullseye|lts
 5.0,5.0,debian-9,5.0
 6.0,6.0,debian-9,6.0|latest
 7.0,7.0,debian-9,7.0

--- a/Config/nodeVersionTemplateMap.txt
+++ b/Config/nodeVersionTemplateMap.txt
@@ -1,3 +1,2 @@
-12,12,pm2-template,12-lts|12.9
 14,14,node-template,14-lts
 16,16,node-template,16-lts|latest|lts

--- a/Config/php-xdebugVersionTemplateMap.txt
+++ b/Config/php-xdebugVersionTemplateMap.txt
@@ -1,8 +1,4 @@
-5.6-apache-xdebug,5.6-apache,5-apache-xdebug,5.6-apache-xdebug
-7.0-apache-xdebug,7.0-apache,7.0-apache-xdebug,7.0-apache-xdebug
-7.2-apache-xdebug,7.2-apache,7-apache-xdebug,7.2-apache-xdebug
-7.3-apache-xdebug,7.3-apache,7-apache-xdebug,7.3-apache-xdebug
-7.4-apache-xdebug,7.4-apache,7-apache-xdebug,7.4-apache-xdebug
+7.4-apache-xdebug,7.4-apache-xdebug-bullseye
 8.0-apache-xdebug,8.0-apache,8.0-apache-xdebug,8.0-apache-xdebug
 8.0-fpm-xdebug,8.0-fpm,8.0-fpm-xdebug,8.0-fpm-xdebug|latest-xdebug
 8.1-apache-xdebug,8.1-apache,8.1-apache-xdebug,8.1-apache-xdebug

--- a/Config/phpVersionTemplateMap.txt
+++ b/Config/phpVersionTemplateMap.txt
@@ -1,10 +1,5 @@
-5.6-apache,5.6,apache,5.6-apache
-7.0-apache,7.0,apache,7.0-apache
-7.2-apache,7.2,apache,7.2-apache
-7.3-apache,7.3,apache,7.3-apache
-7.3-fpm,7.3-fpm,nginx,7.3-fpm
-7.4-apache,7.4,apache,7.4-apache
-7.4-fpm,7.4-fpm,nginx,7.4-fpm
+7.4-apache,7.4,apache,7.4-apache-bullseye
+7.4-fpm,7.4-fpm,nginx,7.4-fpm-bullseye
 8.0-apache,8.0,apache,8.0-apache
 8.0-fpm,8.0-fpm,nginx,8.0-fpm|latest
 8.1-apache,8.1,apache,8.1-apache

--- a/Config/pythonVersionTemplateMap.txt
+++ b/Config/pythonVersionTemplateMap.txt
@@ -1,6 +1,4 @@
-2.7,2.7,template-2.7,2.7
-3.6,3.6,template-3.6,3.6
-3.7,3.7,template-3.7,3.7
-3.8,3.8,template-3.8,3.8
+3.7,3.7,template-3.7,3.7-bullseye
+3.8,3.8,template-3.8,3.8-bullseye
 3.9,3.9,template-3.9,3.9|latest
 3.10,3.10,template-3.10,3.10

--- a/GenerateDockerFiles/dockerFilesGenerateTask.yml
+++ b/GenerateDockerFiles/dockerFilesGenerateTask.yml
@@ -2,7 +2,7 @@ parameters:
   ascName: WAWS_Container_Images
   acrName: wawsimages.azurecr.io
   baseImageName: "mcr.microsoft.com/oryx"
-  baseImageVersion: "20220721.1"
+  baseImageVersion: "20220718.2"
   appSvcGitUrl: "https://github.com/Azure-App-Service"
   kuduliteInternalRepo: $(KUDU_REPO)
   DiagnosticServerInternalRepo: $(DiagnosticServer_REPO)

--- a/localGenerateDockerFiles.sh
+++ b/localGenerateDockerFiles.sh
@@ -30,7 +30,7 @@ done
 
 artifactStagingDirectory="output/DockerFiles"
 baseImageName="${oryxBaseImageName:="mcr.microsoft.com/oryx"}" 
-baseImageVersion="${oryxTagName:="20220721.1"}" # change me as needed
+baseImageVersion="${oryxTagName:="20220718.2"}" # change me as needed
 appSvcGitUrl="https://github.com/Azure-App-Service"
 kuduliteBranch="${kuduliteBranch:="dev"}"
 configDir="Config"


### PR DESCRIPTION
- Updating base image tag to 20220718.2 . This contains the dotnetcore 7 preview 6
- Removing the following EOL versions
  - .NET 1.0, 1.1, 2.0, 2.1, 2.2
  - Node 4, 6, 8, 9, 10, 12 -- including all minor versions
  - PHP 5.6, 7.0, 7.2, 7.3
  - Python 2.7, 3.6
 
- Adding -bullseye to the following tags
  - python 3.7, 3.8
  - dotnetcore 3.1
  - php 7.4
