### PR TITLE
Updating node and dotnetcore images uses in kudulite test cases

### DIFF
--- a/Tests/KuduLite/HelloWorld.cs
+++ b/Tests/KuduLite/HelloWorld.cs
@@ -195,9 +195,9 @@ namespace Tests
         [Fact]
         public async Task NodeTests()
         {
-            string runtimeImage = GetImages("nodebuiltImageList").Where(s => s.Contains("12-lts")).First();
+            string runtimeImage = GetImages("nodebuiltImageList").Where(s => s.Contains("14-lts")).First();
             string kuduImage = GetImages("KuduLitebuiltImageList").First();
-            await TestKuduImages("node", "12-lts", "node", kuduImage, runtimeImage, "Hello World!");
+            await TestKuduImages("node", "14-lts", "node", kuduImage, runtimeImage, "Hello World!");
         }
 
         [Fact]
@@ -212,9 +212,9 @@ namespace Tests
                 File.Move("dotnetcore/repository/Program.cs-tmp", "dotnetcore/repository/Program.cs");
             }
 
-            string runtimeImage = GetImages("dotnetcorebuiltImageList").Where(s => s.Contains("3.1")).First();
+            string runtimeImage = GetImages("dotnetcorebuiltImageList").Where(s => s.Contains("6.0")).First();
             string kuduImage = GetImages("KuduLitebuiltImageList").First();
-            await TestKuduImages("dotnetcore", "3.1", "dotnetcore", kuduImage, runtimeImage, "Hello, World!");
+            await TestKuduImages("dotnetcore", "6.0", "dotnetcore", kuduImage, runtimeImage, "Hello, World!");
         }
     }
 }


### PR DESCRIPTION
With EOL stretch images removed in [PR 326](https://github.com/Azure-App-Service/ImageBuilder/pull/326), kudulite test cases must be updated to not use EOL node-12 and dotnetcore 3.1 images for testing