### PR TITLE
Update oryx base for ant 99 stretch

### DIFF
--- a/GenerateDockerFiles/dockerFilesGenerateTask.yml
+++ b/GenerateDockerFiles/dockerFilesGenerateTask.yml
@@ -2,7 +2,7 @@ parameters:
   ascName: WAWS_Container_Images
   acrName: wawsimages.azurecr.io
   baseImageName: "mcr.microsoft.com/oryx"
-  baseImageVersion: "20220704.1"
+  baseImageVersion: "20220308.4"
   appSvcGitUrl: "https://github.com/Azure-App-Service"
   kuduliteInternalRepo: $(KUDU_REPO)
   DiagnosticServerInternalRepo: $(DiagnosticServer_REPO)

--- a/localGenerateDockerFiles.sh
+++ b/localGenerateDockerFiles.sh
@@ -30,7 +30,7 @@ done
 
 artifactStagingDirectory="output/DockerFiles"
 baseImageName="${oryxBaseImageName:="mcr.microsoft.com/oryx"}" 
-baseImageVersion="${oryxTagName:="20220704.1"}" # change me as needed
+baseImageVersion="${oryxTagName:="20220308.4"}" # change me as needed
 appSvcGitUrl="https://github.com/Azure-App-Service"
 kuduliteBranch="${kuduliteBranch:="dev"}"
 configDir="Config"


### PR DESCRIPTION
Update Oryx base image for ANT 99 stretch images to 20220308.4 (one used in ANT 98)