### PR TITLE
fix AFD warning

### DIFF
--- a/GenerateDockerFiles/wordpress/wordpress/wordpress_src/wordpress-azure/wp-config.php
+++ b/GenerateDockerFiles/wordpress/wordpress/wordpress_src/wordpress-azure/wp-config.php
@@ -114,13 +114,9 @@ if (!preg_match("/^localhost(:[0-9])*/", $_SERVER['HTTP_HOST']) && !preg_match("
 	$http_protocol='https://';
 }
 
-$site_url = $_SERVER['HTTP_HOST'];
-
-# site_url for Azure Front Door (if enabled).
-
 //Relative URLs for swapping across app service deployment slots
-define('WP_HOME', $http_protocol . $site_url);
-define('WP_SITEURL', $http_protocol . $site_url);
+define('WP_HOME', $http_protocol . $_SERVER['HTTP_HOST']);
+define('WP_SITEURL', $http_protocol . $_SERVER['HTTP_HOST']);
 define('WP_CONTENT_URL', '/wp-content');
 define('DOMAIN_CURRENT_SITE', $_SERVER['HTTP_HOST']);
 

--- a/GenerateDockerFiles/wordpress/wordpress_with_mariadb/local_bin/entrypoint.sh
+++ b/GenerateDockerFiles/wordpress/wordpress_with_mariadb/local_bin/entrypoint.sh
@@ -269,10 +269,10 @@ setup_wordpress() {
         if [ "$IS_BLOB_STORAGE_ENABLED" == "True" ] && [ $(grep "BLOB_STORAGE_CONFIGURATION_COMPLETE" $WORDPRESS_LOCK_FILE) ] \
         && [ ! $(grep "BLOB_AFD_CONFIGURATION_COMPLETE" $WORDPRESS_LOCK_FILE) ]; then
             start_at_daemon
-            echo "bash /usr/local/bin/w3tc_cdn_config.sh BLOB_AFD" | at now +10 minutes
+            echo "bash /usr/local/bin/w3tc_cdn_config.sh BLOB_AFD" | at now +2 minutes
         elif [ "$IS_BLOB_STORAGE_ENABLED" != "True" ] && [ ! $(grep "AFD_CONFIGURATION_COMPLETE" $WORDPRESS_LOCK_FILE) ]; then
             start_at_daemon
-            echo "bash /usr/local/bin/w3tc_cdn_config.sh AFD" | at now +10 minutes
+            echo "bash /usr/local/bin/w3tc_cdn_config.sh AFD" | at now +2 minutes
         fi
     fi
 
@@ -417,6 +417,20 @@ if ! [[ $SKIP_WP_INSTALLATION ]] || ! [[ "$SKIP_WP_INSTALLATION" == "true"
     setup_wordpress
 else 
     echo "INFO: Skipping WP installation..."
+fi
+
+#Update AFD URL
+if [ $(grep "BLOB_AFD_CONFIGURATION_COMPLETE" $WORDPRESS_LOCK_FILE) ] || [ $(grep "AFD_CONFIGURATION_COMPLETE" $WORDPRESS_LOCK_FILE) ]; then
+    afd_url="\$http_protocol . \$_SERVER['HTTP_HOST']"
+    if [[ $AFD_ENABLED ]]; then
+        if [[ $AFD_CUSTOM_DOMAIN ]]; then
+            afd_url="\$http_protocol . '$AFD_CUSTOM_DOMAIN'"
+        elif [[ $AFD_ENDPOINT ]]; then
+            afd_url="\$http_protocol . '$AFD_ENDPOINT'"
+        fi
+    fi
+    wp config set WP_HOME "$afd_url" --raw --path=$WORDPRESS_HOME --allow-root 
+    wp config set WP_SITEURL "$afd_url" --raw --path=$WORDPRESS_HOME --allow-root 
 fi
 
 if [ -e "$WORDPRESS_HOME/wp-config.php" ]; then

--- a/GenerateDockerFiles/wordpress/wordpress_with_mariadb/wordpress_src/wordpress-azure/wp-config.php
+++ b/GenerateDockerFiles/wordpress/wordpress_with_mariadb/wordpress_src/wordpress-azure/wp-config.php
@@ -114,13 +114,9 @@ if (!preg_match("/^localhost(:[0-9])*/", $_SERVER['HTTP_HOST']) && !preg_match("
 	$http_protocol='https://';
 }
 
-$site_url = $_SERVER['HTTP_HOST'];
-
-# site_url for Azure Front Door (if enabled).
-
 //Relative URLs for swapping across app service deployment slots
-define('WP_HOME', $http_protocol . $site_url);
-define('WP_SITEURL', $http_protocol . $site_url);
+define('WP_HOME', $http_protocol . $_SERVER['HTTP_HOST']);
+define('WP_SITEURL', $http_protocol . $_SERVER['HTTP_HOST']);
 define('WP_CONTENT_URL', '/wp-content');
 define('DOMAIN_CURRENT_SITE', $_SERVER['HTTP_HOST']);
 


### PR DESCRIPTION
Use static values for WP constants (WP_HOME and WP_SITEURL) declared in wp-config.php file.
Upon restart (in entrypoint file), update these constants based AFD_ENABLED, AFD_ENDPOINT and AFD_CUSTOM_DOMAIN app settings.