### PR TITLE
update wordpress tags

### DIFF
--- a/Config/wordpressVersionTemplateMap.txt
+++ b/Config/wordpressVersionTemplateMap.txt
@@ -1,2 +1,2 @@
-1.1,7.4.24-fpm-alpine3.13,wordpress,1.1|latest_7.4
-1.2,8.0.25-fpm-alpine3.15,wordpress,1.2|test
+7.4,7.4.24-fpm-alpine3.13,wordpress,7.4|latest_7.4
+8.0,8.0.25-fpm-alpine3.15,wordpress,8.0|test


### PR DESCRIPTION
Updated BuildID tags from 1.1_buildID to 7.4_buildID and 1.2_buildID to 8.0_buildID.