### PR TITLE
Update wordpress base image

### DIFF
--- a/Config/wordpressVersionTemplateMap.txt
+++ b/Config/wordpressVersionTemplateMap.txt
@@ -1,2 +1,2 @@
 7.4,7.4.24-fpm-alpine3.13,wordpress,7.4|latest_7.4
-8.0,8.0.27-fpm-alpine3.16,wordpress,test
+8.0,8.0.28-fpm-alpine3.16,wordpress,test

--- a/GenerateDockerFiles/wordpress/wordpress/Dockerfile
+++ b/GenerateDockerFiles/wordpress/wordpress/Dockerfile
@@ -195,7 +195,7 @@ RUN set -ex \
 		zlib-dev \
 		linux-headers \
 		curl \
-		gnupg1 \
+		gnupg \
 		libxslt-dev \
 		gd-dev \
 		geoip-dev \

--- a/GenerateDockerFiles/wordpress/wordpress_with_mariadb/Dockerfile
+++ b/GenerateDockerFiles/wordpress/wordpress_with_mariadb/Dockerfile
@@ -191,7 +191,7 @@ RUN set -ex \
 		zlib-dev \
 		linux-headers \
 		curl \
-		gnupg1 \
+		gnupg \
 		libxslt-dev \
 		gd-dev \
 		geoip-dev \


### PR DESCRIPTION
Previous base image: php:8.0.27-fpm-alpine3.16
New base image: php:8.0.28-fpm-alpine3.16