### PR TITLE
Prevent Startup script retries

### DIFF
--- a/GenerateDockerFiles/wordpress/wordpress/supervisord-original.conf
+++ b/GenerateDockerFiles/wordpress/wordpress/supervisord-original.conf
@@ -37,3 +37,6 @@ stderr_logfile_maxbytes=0
 
 [program:post-startup-script]
 command=bash /home/dev/startup.sh
+autostart=true
+autorestart=false
+startretries=0

--- a/GenerateDockerFiles/wordpress/wordpress/supervisord-stgoptmzd.conf
+++ b/GenerateDockerFiles/wordpress/wordpress/supervisord-stgoptmzd.conf
@@ -93,3 +93,6 @@ startretries=1000
 
 [program:post-startup-script]
 command=bash /home/dev/startup.sh
+autostart=true
+autorestart=false
+startretries=0


### PR DESCRIPTION
Udpated post-startup-string program in supervisor to define startretries=0 for preventing multiple retries.