### PR TITLE
enabling debug log with wordpress & php-fpm

### DIFF
--- a/GenerateDockerFiles/wordpress/wordpress/Dockerfile
+++ b/GenerateDockerFiles/wordpress/wordpress/Dockerfile
@@ -14,6 +14,7 @@ ENV PHP_HOME "/usr/local/etc/php"
 ENV PHP_CONF_DIR $PHP_HOME
 ENV PHP_CONF_FILE $PHP_CONF_DIR"/php.ini"
 ENV PHP_CUSTOM_CONF_FILE $PHP_CONF_DIR"/conf.d/uploads.ini"
+ENV PHP_FPM_LOG_DIR "/var/log/php-fpm"
 #Upper bounds of php configs
 ENV UB_PHP_MEMORY_LIMIT 512M
 ENV UB_UPLOAD_MAX_FILESIZE 256M
@@ -285,6 +286,10 @@ RUN set -ex \
 	&& chown -R nginx:nginx $HOME_SITE_LOCAL_STG \
 	&& chmod -R 777 $HOME_SITE \
 	&& chmod -R 777 $HOME_SITE_LOCAL_STG \
+	# create php-fpm log directory
+	&& mkdir -p ${PHP_FPM_LOG_DIR} \
+	&& chown -R nginx:nginx $PHP_FPM_LOG_DIR \
+	&& chmod -R 777 $PHP_FPM_LOG_DIR \
 # -------------
 # log rotate & supervisor
 # -------------

--- a/GenerateDockerFiles/wordpress/wordpress/php_fpm_conf/www.conf
+++ b/GenerateDockerFiles/wordpress/wordpress/php_fpm_conf/www.conf
@@ -425,6 +425,6 @@ clear_env = no
 ;                specified at startup with the -d argument
 ;php_admin_value[sendmail_path] = /usr/sbin/sendmail -t -i -f www@my.domain.com
 ;php_flag[display_errors] = off
-php_admin_value[error_log] = /var/log/fpm-php.www.log
+php_admin_value[error_log] = /var/log/php-fpm/php-fpm.www.log
 php_admin_flag[log_errors] = on
 ;php_admin_value[memory_limit] = 512M


### PR DESCRIPTION

Fixed the issue where logs were not being generated for WordPress.
Debug logs would now be available under: **/var/log/php-fpm/php-fpm.www.log**